### PR TITLE
This makes it compile on debian unstable, probably many others too.

### DIFF
--- a/README
+++ b/README
@@ -8,5 +8,5 @@ To test, run the sample D-Bus service first:
 
 Then run the test script in node:
 	
-	node test_method.js
+	node examples/test_method.js
 

--- a/src/dbus.cc
+++ b/src/dbus.cc
@@ -9,6 +9,7 @@
 #include <map>
 #include <iostream>
 
+#include "dbus.h"
 #include "dbus_introspect.h"
 
 using namespace v8;
@@ -1053,13 +1054,13 @@ static void prepare_cb (EV_P_ ev_prepare *w, int revents) {
         );
     iow->data = (void *)pfd;
     ev_set_priority (iow, EV_MINPRI);
-    ev_io_start (EV_A iow);
+    ev_io_start (EV_A_ iow);
   }
 
   if (timeout >= 0)
   {
     ev_timer_set (&ctx->tw, timeout * 1e-3, 0.);
-    ev_timer_start (EV_A &ctx->tw);
+    ev_timer_start (EV_A_ &ctx->tw);
   }
 }
 
@@ -1074,18 +1075,18 @@ static void check_cb (EV_P_ ev_check *w, int revents) {
     if (ev_is_pending (iow))
     {
       GPollFD *pfd = ctx->pfd + i;
-      int revents = ev_clear_pending (EV_A iow);
+      int revents = ev_clear_pending (EV_A_ iow);
 
       pfd->revents |= pfd->events &
         ((revents & EV_READ ? G_IO_IN : 0)
          | (revents & EV_WRITE ? G_IO_OUT : 0));
     }
 
-    ev_io_stop (EV_A iow);
+    ev_io_stop (EV_A_ iow);
   }
 
   if (ev_is_active (&ctx->tw))
-    ev_timer_stop (EV_A &ctx->tw);
+    ev_timer_stop (EV_A_ &ctx->tw);
 
   //FIXME: would block here when run in non-interactive mode, because "prepare_cb" not called
   //oops, event loop  block here, the "prepare_cb" is never called and so blocks here
@@ -1125,12 +1126,12 @@ init (Handle<Object> target)
   ev_prepare_init (&ctx->pw, prepare_cb);
   ev_set_priority (&ctx->pw, EV_MINPRI);
   ev_prepare_start (EV_DEFAULT_UC_ &ctx->pw);
-  ev_unref(EV_DEFAULT_UC_);
+  ev_unref(EV_DEFAULT_UC);
 
   ev_check_init (&ctx->cw, check_cb);
   ev_set_priority (&ctx->cw, EV_MAXPRI);
   ev_check_start (EV_DEFAULT_UC_ &ctx->cw);
-  ev_unref(EV_DEFAULT_UC_);
+  ev_unref(EV_DEFAULT_UC);
 
   ev_init (&ctx->tw, timer_cb);
   ev_set_priority (&ctx->tw, EV_MINPRI);

--- a/src/dbus.h
+++ b/src/dbus.h
@@ -5,6 +5,7 @@
 #include <node_object_wrap.h>
 #include <v8.h>
 #include <ev.h>
+#include <cstdlib>
 
 #endif
 


### PR DESCRIPTION
First I got errors about "free" and such not being defined. so I added the <cstdlib> include.

Then it took me approximately 8 billion years to figure out why I was getting syntax errors in some of your libev calls. But I got it!

This section: http://pod.tst.eu/http://cvs.schmorp.de/libev/ev.pod#MACRO_MAGIC

Has variations of the macros based on whether an argument follows or not. A trailing underscore is for when there are more arguments. Most of this patch just fixes the trailing underscores.

Now it seems to build and run fine. (the test_method.js spit out lots of text.)

Thanks for your node module!
