### PR TITLE
no need a wrapper for array type messages

### DIFF
--- a/lib/dbus_register.js
+++ b/lib/dbus_register.js
@@ -11,10 +11,12 @@ module.exports = function(_dbus, _bus) {
 				continue;
 
 			if (member in registerObject[path][interface]['Methods']) {
-        // args is null or undefined cause error on Array.prototype.slice.call
-        if (! args)
-          return registerObject[path][interface]['Methods'][member].apply(this, args);
-        return registerObject[path][interface]['Methods'][member].apply(this, Array.prototype.slice.call(args));
+				// args is null or undefined cause error on Array.prototype.slice.call
+
+				if (! args)
+					return registerObject[path][interface]['Methods'][member].apply(this, [ args ]);
+
+				return registerObject[path][interface]['Methods'][member].apply(this, Array.prototype.slice.call(args));
 			}
 		}
 	};

--- a/src/dbus.cc
+++ b/src/dbus.cc
@@ -626,7 +626,7 @@ static void async_method_callback(DBusPendingCall *pending, void *user_data)
     return;
   }
   //create the execution context since its in new context
-  Local<Context> context = Context::GetCurrent();
+  Persistent<Context> context = Context::New();
   Context::Scope ctxScope(context);
   HandleScope scope;
   TryCatch try_catch;
@@ -637,6 +637,7 @@ static void async_method_callback(DBusPendingCall *pending, void *user_data)
 
   if (! finish_callback->IsFunction()) {
     ERROR("The callback is not a Function\n");
+    context.Dispose();
 
     dbus_message_unref(reply_message);
     dbus_pending_call_unref(pending);
@@ -656,6 +657,8 @@ static void async_method_callback(DBusPendingCall *pending, void *user_data)
   if (try_catch.HasCaught()) {
     ERROR("Ooops, Exception on call the callback\n");
   }
+
+  context.Dispose();
 
   dbus_message_unref(reply_message);
   dbus_pending_call_unref(pending);
@@ -857,7 +860,7 @@ static DBusHandlerResult dbus_signal_filter(DBusConnection* connection,
   } 
 
   //create the execution context since its in new context
-  Local<Context> context = Context::GetCurrent();
+  Persistent<Context> context = Context::New();
   Context::Scope ctxScope(context); 
   HandleScope scope;
   TryCatch try_catch;
@@ -873,14 +876,17 @@ static DBusHandlerResult dbus_signal_filter(DBusConnection* connection,
   if ( callback_enabled == Undefined() 
                       || callback_v == Undefined()) {
     ERROR("Callback undefined\n");
+    context.Dispose();
     return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
   }
   if (! callback_enabled->ToBoolean()->Value()) {
     ERROR("Callback not enabled\n");
+    context.Dispose();
     return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
   }
   if (! callback_v->IsFunction()) {
     ERROR("The callback is not a Function\n");
+    context.Dispose();
     return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
   }
 
@@ -893,12 +899,17 @@ static DBusHandlerResult dbus_signal_filter(DBusConnection* connection,
   args[0] = arg0; 
 
   //Do call the callback
-  callback->Call(callback, 1, args);
+  if (arg0->IsArray()) {
+      callback->Call(callback, arg0->ToObject()->GetPropertyNames()->Length(), &arg0);
+  } else {
+      callback->Call(callback, 1, args);
+  }
 
   if (try_catch.HasCaught()) {
     ERROR("Ooops, Exception on call the callback\n");
   } 
   
+  context.Dispose();
   return DBUS_HANDLER_RESULT_HANDLED;
 }
 


### PR DESCRIPTION
Making callback function able to get all arguments with normal way rather than a big object.
