### PR TITLE
Using GYP to be build script instead of wscript

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,0 +1,35 @@
+{
+	'targets': [
+		{
+			'target_name': 'dbus',
+			'sources': [
+				'src/dbus.cc',
+				'src/context.cc',
+				'src/dbus_introspect.cc',
+				'src/dbus_register.cc'
+			],
+			'copies': [{
+				'destination': '<(module_root_dir)/lib/',
+				'files': [
+					'<(module_root_dir)/build/Release/dbus.node'
+				]
+			}],
+			'conditions': [
+				['OS=="linux"', {
+					'cflags': [
+						'<!@(pkg-config --cflags dbus-1)',
+						'<!@(pkg-config --cflags dbus-glib-1)'
+					],
+					'ldflags': [
+						'<!@(pkg-config  --libs-only-L --libs-only-other dbus-1)',
+						'<!@(pkg-config  --libs-only-L --libs-only-other dbus-glib-1)'
+					],
+					'libraries': [
+						'<!@(pkg-config  --libs-only-l --libs-only-other dbus-1)',
+						'<!@(pkg-config  --libs-only-l --libs-only-other dbus-glib-1)'
+					]
+				}]
+			]
+		}
+	]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name" : "dbus",
-  "version" : "0.0.5",
+  "version" : "0.0.6",
   "description": "A D-Bus binding for Node",
   "author" : "Shouqun Liu <liushouqun@gmail.com>",
   "repository" : {
@@ -9,6 +9,6 @@
   },
   "main" : "./lib/dbus",
   "scripts" : {
-    "install" : "node-waf configure build"
+    "install" : "node-gyp configure build"
   }
 }


### PR DESCRIPTION
- Using GYP to be build script instead of wscript, because wscript is deprecated in latest version of Node.js
- pump version to v0.0.6
