### PR TITLE
Changed IntegerValue to NumberValue for ints

### DIFF
--- a/src/dbus.cc
+++ b/src/dbus.cc
@@ -370,7 +370,7 @@ bool encode_to_message_with_objects(Local<Value> value,
     case DBUS_TYPE_UINT32:
     case DBUS_TYPE_UINT64:
     case DBUS_TYPE_BYTE: {
-      dbus_uint64_t data = value->IntegerValue();
+      dbus_uint64_t data = value->NumberValue();
       if (!dbus_message_iter_append_basic(iter, type, &data)) {
         ERROR("Error append numeric\n");
         return false;


### PR DESCRIPTION
It seems that IntegerValue() in V8 is limited, on 32 bit version of Node.js, to a 32 bit integer.
With node 0.8.*, an integer overflow occurs when trying to read uint64 types from DBus.

NumberValue(), on the other hand, does not seem to have a limit.
