### PR TITLE
Fixed decoding of 64 bit integers

### DIFF
--- a/src/dbus.cc
+++ b/src/dbus.cc
@@ -222,7 +222,7 @@ static Handle<Value> decode_reply_message_by_iter(
     case DBUS_TYPE_UINT64: {
       dbus_uint64_t value = 0; 
       dbus_message_iter_get_basic(iter, &value);
-      return Integer::New(value);
+      return Number::New(value);
       break;
     }
     case DBUS_TYPE_DOUBLE: {


### PR DESCRIPTION
It seems that Integer in V8 is limited, on 32 bit version of Node.js, to a 32 bit integer.
With node 0.8.*, an integer overflow occurs when trying to read uint64 types from DBus.

Number, on the other hand, does not seem to have a limit.

I am not sure if this bug would also exist for encoding values, since IntegerValue() is used
there, again for 64 bit integers. 
