### PR TITLE
Fixed receiving arguments on services

### DIFF
--- a/lib/dbus_register.js
+++ b/lib/dbus_register.js
@@ -1,4 +1,3 @@
-
 module.exports = function(_dbus, _bus) {
 	var self = this;
 	var dbus = _dbus;
@@ -16,7 +15,7 @@ module.exports = function(_dbus, _bus) {
 				if (! args)
 					return registerObject[path][interface]['Methods'][member].apply(this, [ args ]);
 
-				return registerObject[path][interface]['Methods'][member].apply(this, Array.prototype.slice.call(args));
+				return registerObject[path][interface]['Methods'][member].apply(this, Array.prototype.slice.call(Array.isArray(args) ? args : [ args ] ));
 			}
 		}
 	};


### PR DESCRIPTION
Seems that this particular piece of code incorrectly assumes args will be an array of arguments,
while the C++ code that translates DBus Messages into V8 objects returns an array
only if there are more than one arguments. When there is only one argument, Array.prototype.slice.call
is incorrectly called on that argument.
The result is chaotic: numbers are not received at all and strings are received one character per argument.

I am concerned that since the expected result of decode_reply_messages seems to be an array, this bug might be present for more cases.
