### PR TITLE
Improve error reporting, dbus error is now returned when GetBus() fails.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,15 @@
 node-dbus is a D-Bus binding for Node.js.
 
 ## How To Build
-To build, do: `node-gyp configure build`
+To build, do: `node-gyp configure build` or `npm install`.
+
+## Note on systems without X11
+If no X server is running, the module fails when attempting to obtain a D-Bus
+connection at `dbus._dbus.getBus()`. This can be remedied by setting two
+environment variables manually (the actual bus address might be different):
+
+	process.env.DISPLAY = ':0';
+	process.env.DBUS_SESSION_BUS_ADDRESS = 'unix:path=/run/dbus/system_bus_socket';
 
 ## License 
 

--- a/src/dbus.cc
+++ b/src/dbus.cc
@@ -77,7 +77,7 @@ namespace NodeDBus {
 		dbus_error_init(&error);
 
 		if (!args[0]->IsNumber())
-			return ThrowException(Exception::Error(String::New("First parameter is integer")));
+			return ThrowException(Exception::TypeError(String::New("First parameter must be an integer")));
 
 		// Create connection
 		switch(args[0]->IntegerValue()) {
@@ -90,8 +90,10 @@ namespace NodeDBus {
 			break;
 		}
 
-		if (connection == NULL)
-			return ThrowException(Exception::Error(String::New("Failed to get bus object")));
+		if (connection == NULL) {
+			if (dbus_error_is_set(&error)) return ThrowException(Exception::Error(String::New(error.message)));
+			else return ThrowException(Exception::Error(String::New("Failed to get bus object")));
+		}
 
 		// Initializing connection object
 		Handle<ObjectTemplate> object_template = ObjectTemplate::New();
@@ -141,7 +143,7 @@ namespace NodeDBus {
 
 		// Get bus from internal field
 		if (!args[0]->IsObject())
-			return ThrowException(Exception::Error(String::New("First argument must be a object ")));
+			return ThrowException(Exception::TypeError(String::New("First argument must be an object ")));
 
 		Local<Object> bus_object = args[0]->ToObject();
 		BusObject *bus = static_cast<BusObject *>(External::Unwrap(bus_object->GetInternalField(0)));
@@ -248,7 +250,7 @@ namespace NodeDBus {
 
 		if (!args[0]->IsObject()) {
 			return ThrowException(Exception::TypeError(
-				String::New("first argument must be a object (bus)")
+				String::New("first argument must be an object (bus)")
 			));
 		}
 

--- a/src/object_handler.cc
+++ b/src/object_handler.cc
@@ -105,7 +105,7 @@ namespace ObjectHandler {
 
 		if (!args[0]->IsObject()) {
 			return ThrowException(Exception::TypeError(
-				String::New("first argument must be a object (bus)")
+				String::New("first argument must be an object (bus)")
 			));
 		}
 
@@ -140,7 +140,7 @@ namespace ObjectHandler {
 
 		if (!args[0]->IsObject()) {
 			return ThrowException(Exception::TypeError(
-				String::New("first argument must be a object")
+				String::New("first argument must be an object")
 			));
 		}
 
@@ -163,7 +163,7 @@ namespace ObjectHandler {
 
 		if (!args[0]->IsObject()) {
 			return ThrowException(Exception::TypeError(
-				String::New("first argument must be a object")
+				String::New("first argument must be an object")
 			));
 		}
 

--- a/src/signal.cc
+++ b/src/signal.cc
@@ -43,7 +43,7 @@ namespace Signal {
 
 		if (!args[0]->IsObject()) {
 			return ThrowException(Exception::TypeError(
-				String::New("first argument must be a object")
+				String::New("first argument must be an object")
 			));
 		}
 


### PR DESCRIPTION
The specific error is very useful to debug general dbus issues. The problem at hand that led to this improvement was the absence of an X11 server, causing dbus to fail. Hence also the added note in the readme.
