### PR TITLE
Fix strict statement in bus.js

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -1,4 +1,4 @@
-"usr strict";
+"use strict";
 
 var util = require('util');
 var events = require('events');


### PR DESCRIPTION
It was "usr strict" - changed it to "use strict".