### PR TITLE
Only attach signal handler to a single connection

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -34,7 +34,7 @@ var Bus = module.exports = function(dbus, busName) {
 			return;
 		}
 
-		var signalHash = objectPath + ':' + interfaceName;
+		var signalHash = sender + ':' + objectPath + ':' + interfaceName;
 
 		if (self.signalHandlers[signalHash]) {
 			var args = [ signalName ].concat(args);
@@ -151,12 +151,14 @@ Bus.prototype.getInterface = function(serviceName, objectPath, interfaceName, ca
 Bus.prototype.registerSignalHandler = function(serviceName, objectPath, interfaceName, interfaceObj, callback) {
 	var self = this;
 
-	// Make a hash
-	var signalHash = objectPath + ':' + interfaceName;
-	self.signalHandlers[signalHash] = interfaceObj;
+	self.getUniqueServiceName(serviceName, function (err, uniqueName) {
+		// Make a hash
+		var signalHash = uniqueName + ':' + objectPath + ':' + interfaceName;
+		self.signalHandlers[signalHash] = interfaceObj;
 
-	// Register interface signal handler
-	self.dbus.addSignalFilter(self, objectPath, interfaceName, callback);
+		// Register interface signal handler
+		self.dbus.addSignalFilter(self, objectPath, interfaceName, callback);
+	});
 };
 
 Bus.prototype.setMaxMessageSize = function(size) {
@@ -164,3 +166,19 @@ Bus.prototype.setMaxMessageSize = function(size) {
 
 	self.dbus.setMaxMessageSize(self, size || 1024000);
 };
+
+Bus.prototype.getUniqueServiceName = function(serviceName, callback) {
+	var self = this;
+
+	self.dbus.callMethod(self.connection,
+		'org.freedesktop.DBus',
+		'/',
+		'org.freedesktop.DBus',
+		'GetNameOwner',
+		's',
+		-1,
+		[serviceName],
+		function(err, uniqueName) {
+			callback(err, uniqueName);
+		});
+}


### PR DESCRIPTION
This fix attaches each signal handler to the unique dbus connection ID (obtained with [getNameOwner](http://dbus.freedesktop.org/doc/dbus-specification.html#bus-messages-get-name-owner)).

See issue #71.