### PR TITLE
fix build against nodejs v0.10.x

### DIFF
--- a/src/connection.cc
+++ b/src/connection.cc
@@ -218,12 +218,12 @@ namespace Connection {
 		NanScope();
 
 		// Getting arguments of signal
-		Local<Value> arguments = Decoder::DecodeArguments(message);
+		Handle<Value> arguments = Decoder::DecodeArguments(message);
 		Local<Value> senderValue = NanNull();
 		if (sender)
 			senderValue = NanNew<String>(sender);
 
-		Local<Value> args[] = {
+		Handle<Value> args[] = {
 			NanNew<String>(dbus_bus_get_unique_name(connection)),
 			senderValue,
 			NanNew<String>(object_path),

--- a/src/dbus.cc
+++ b/src/dbus.cc
@@ -267,7 +267,6 @@ namespace NodeDBus {
 
 		if (!args[0]->IsString()) {
 			NanReturnNull();
-			return;
 		}
 
 		char *src = strdup(*String::Utf8Value(args[0]->ToString()));

--- a/src/dbus.cc
+++ b/src/dbus.cc
@@ -44,8 +44,8 @@ namespace NodeDBus {
 		}
 
 		// Decode message for arguments
-		Local<Value> result = Decoder::DecodeMessage(reply_message);
-		Local<Value> args[] = {
+		Handle<Value> result = Decoder::DecodeMessage(reply_message);
+		Handle<Value> args[] = {
 			err,
 			result
 		};

--- a/src/object_handler.cc
+++ b/src/object_handler.cc
@@ -37,9 +37,9 @@ namespace ObjectHandler {
 		NanSetInternalFieldPointer(message_object, 1, message);
 
 		// Getting arguments
-		Local<Value> arguments = Decoder::DecodeArguments(message);
+		Handle<Value> arguments = Decoder::DecodeArguments(message);
 
-		Local<Value> args[] = {
+		Handle<Value> args[] = {
 			NanNew<String>(dbus_bus_get_unique_name(connection)),
 			NanNew<String>(sender),
 			NanNew<String>(object_path),

--- a/src/object_handler.cc
+++ b/src/object_handler.cc
@@ -136,7 +136,6 @@ namespace ObjectHandler {
 
 		if (dbus_message_get_no_reply(message)) {
 			NanReturnUndefined();
-			return;
 		}
 
 		char *signature = strdup(*NanUtf8String(args[2]));

--- a/src/signal.cc
+++ b/src/signal.cc
@@ -15,7 +15,7 @@ namespace Signal {
 	using namespace std;
 
 	//Persistent<Function> handler = Persistent<Function>::New(Handle<Function>::Cast(NanNull()));
-	bool hookSignal = False;
+	bool hookSignal = false;
 	Persistent<Function> handler;
 
 	void DispatchSignal(Handle<Value> args[])
@@ -35,7 +35,7 @@ namespace Signal {
 //		handler.Dispose();
 //		handler.Clear();
 
-		hookSignal = True;
+		hookSignal = true;
 		NanAssignPersistent(handler, args[0].As<Function>());
 //		handler = Persistent<Function>::New(Handle<Function>::Cast(args[0]));
 


### PR DESCRIPTION
Please pull the following changesets to fix the build against nodejs v0.10.x

- use `Handle<Value>` rather than `Local<Value>` where appropriate
- fix return-statement with no value, in function returning `v8::Handle<v8::Value>`
- replace `True` with `true` and `False` with `false`

All three patches are required in order to build against nodejs v0.10.x

Tested against nodejs v0.10.26 and nodejs v0.12.4