### PR TITLE
introspect: create an ouput argument array

### DIFF
--- a/src/introspect.cc
+++ b/src/introspect.cc
@@ -63,6 +63,7 @@ namespace Introspect {
 			// Create a new object for this method
 			Local<Object> method = NanNew<Object>();
 			method->Set(NanNew("in"), NanNew<Array>());
+			method->Set(NanNew("out"), NanNew<Array>());
 
 			method_class->Set(NanNew<String>(GetAttribute(attrs, "name")), method);
 
@@ -113,7 +114,8 @@ namespace Introspect {
 					Local<Array> arguments = Local<Array>::Cast(method->Get(NanNew("in")));
 					arguments->Set(arguments->Length(), NanNew<String>(GetAttribute(attrs, "type")));
 				} else {
-					method->Set(NanNew("out"), NanNew<String>(GetAttribute(attrs, "type")));
+					Local<Array> arguments = Local<Array>::Cast(method->Get(NanNew("out")));
+					arguments->Set(arguments->Length(), NanNew<String>(GetAttribute(attrs, "type")));
 				}
 
 				break;


### PR DESCRIPTION
Without this patch no list is created from the output arguments. This is
different from how the input arguments are handled. Only the last output argument
is then seen in the introspection, what is wrong.