### PR TITLE
connection.cc: don't add two watchers for one fd

### DIFF
--- a/src/connection.cc
+++ b/src/connection.cc
@@ -103,6 +103,13 @@ namespace Connection {
 
 	static void watch_handle(DBusWatch *watch, void *data)
 	{
+		// This watch was never added, so don't do anything!
+		// If we would react in this case, it can happen that we add
+		// two watches for one filehandler, this crashes libuv!
+		if (dbus_watch_get_data(watch) == NULL) {
+			return;
+		}
+
 		if (dbus_watch_get_enabled(watch))
 			watch_add(watch, data);
 		else
@@ -135,7 +142,7 @@ namespace Connection {
 	}
 
 	static dbus_bool_t timeout_add(DBusTimeout *timeout, void *data)
-	{ 
+	{
 		if (!dbus_timeout_get_enabled(timeout) || dbus_timeout_get_data(timeout) != NULL)
 			return true;
 
@@ -212,7 +219,7 @@ namespace Connection {
 		// Getting V8 context
 /*
 		Local<Context> context = Context::GetCurrent();
-		Context::Scope ctxScope(context); 
+		Context::Scope ctxScope(context);
 		HandleScope scope;
 */
 		NanScope();


### PR DESCRIPTION
If a lot of data is transfered over D-Bus it is possible that
watch_handle is called with a watch that was never added. This handle
can then have a file descriptor, that already belongs to an other watch.
If watch_add ist called in this scenario, an new uv watcher will be
created. This then crashes libuv.

output of a debugging session:
watch_add
watch_add
fd: 9
Watch pt: 0x3377a60 // Watch for fd 9 added

// Here the problem starts:
watch_handle
// This watch was never added!
Watch pt: 0x3377a10
// Add it now
watch_add
fd: 9
Watch pt: 0x3377a10
// Crash because watch with pt 0x3377a60 is already registered for fd 9
node: ../deps/uv/src/unix/core.c:855: uv__io_stop: Assertion `loop->watchers[w->fd] == w' failed.
Aborted