### PR TITLE
fix build using nan 2.1.0 against nodejs v0.10.x

### DIFF
--- a/src/dbus.cc
+++ b/src/dbus.cc
@@ -35,7 +35,7 @@ namespace NodeDBus {
 		// Get current context from V8
 		Nan::HandleScope scope;
 
-		Handle<Value> err = Nan::Null();
+		Local<Value> err = Nan::Null();
 		if (dbus_error_is_set(&error)) {
 			err = Nan::Error(error.message);
 			dbus_error_free(&error);
@@ -44,8 +44,8 @@ namespace NodeDBus {
 		}
 
 		// Decode message for arguments
-		Handle<Value> result = Decoder::DecodeMessage(reply_message);
-		Handle<Value> info[] = {
+		Local<Value> result = Decoder::DecodeMessage(reply_message);
+		Local<Value> info[] = {
 			err,
 			result
 		};
@@ -271,7 +271,7 @@ namespace NodeDBus {
 
 		char *src = strdup(*String::Utf8Value(info[0]->ToString()));
 
-		Handle<Value> obj = Introspect::CreateObject(src);
+		Local<Value> obj = Introspect::CreateObject(src);
 
 		dbus_free(src);
 

--- a/src/decoder.cc
+++ b/src/decoder.cc
@@ -12,7 +12,7 @@ namespace Decoder {
 	using namespace v8;
 	using namespace std;
 
-	Handle<Value> DecodeMessageIter(DBusMessageIter *iter, const char *signature)
+	Local<Value> DecodeMessageIter(DBusMessageIter *iter, const char *signature)
 	{
 		Nan::EscapableHandleScope scope;
 		DBusSignatureIter siter;
@@ -67,7 +67,7 @@ namespace Decoder {
 			char *sig = NULL;
 
 			// Create a object
-			Handle<Object> result = Nan::New<Object>();
+			Local<Object> result = Nan::New<Object>();
 
 			do {
 				// Getting sub iterator
@@ -125,7 +125,7 @@ namespace Decoder {
 			if (is_dict) {
 
 				// Create a object
-				Handle<Object> result = Nan::New<Object>();
+				Local<Object> result = Nan::New<Object>();
 
 				// Make sure it doesn't empty
 				if (dbus_message_iter_get_arg_type(&internal_iter) == DBUS_TYPE_INVALID)
@@ -164,7 +164,7 @@ namespace Decoder {
 
 			// Create an array
 			unsigned int count = 0;
-			Handle<Array> result = Nan::New<Array>();
+			Local<Array> result = Nan::New<Array>();
 			if (dbus_message_iter_get_arg_type(&internal_iter) == DBUS_TYPE_INVALID)
 				return scope.Escape(result);
 
@@ -193,7 +193,7 @@ namespace Decoder {
 			dbus_message_iter_recurse(iter, &internal_iter);
 
 			sig = dbus_message_iter_get_signature(&internal_iter);
-			Handle<Value> value = DecodeMessageIter(&internal_iter, sig);
+			Local<Value> value = DecodeMessageIter(&internal_iter, sig);
 			dbus_free(sig);
 
 			return scope.Escape(value);
@@ -207,7 +207,7 @@ namespace Decoder {
 		return Nan::Undefined();
 	}
 
-	Handle<Value> DecodeMessage(DBusMessage *message)
+	Local<Value> DecodeMessage(DBusMessage *message)
 	{
 		Nan::EscapableHandleScope scope;
 		DBusMessageIter iter;
@@ -221,10 +221,10 @@ namespace Decoder {
 		if (dbus_message_iter_get_arg_type(&iter) == DBUS_TYPE_INVALID)
 			return Nan::Undefined();
 
-		Handle<Array> result = Nan::New<Array>();
+		Local<Array> result = Nan::New<Array>();
 		unsigned int count = 0;
 		char *signature = NULL;
-		Handle<Value> value;
+		Local<Value> value;
 
 		do {
 			signature = dbus_message_iter_get_signature(&iter);
@@ -245,11 +245,11 @@ namespace Decoder {
 		return scope.Escape(result);
 	}
 
-	Handle<Value> DecodeArguments(DBusMessage *message)
+	Local<Value> DecodeArguments(DBusMessage *message)
 	{
 		Nan::EscapableHandleScope scope;
 		DBusMessageIter iter;
-		Handle<Array> result = Nan::New<Array>();
+		Local<Array> result = Nan::New<Array>();
 
 		if (!dbus_message_iter_init(message, &iter))
 			return scope.Escape(result);

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -7,8 +7,8 @@ namespace Decoder {
 	using namespace v8;
 	using namespace std;
 
-	Handle<Value> DecodeMessage(DBusMessage *message);
-	Handle<Value> DecodeArguments(DBusMessage *message);
+	Local<Value> DecodeMessage(DBusMessage *message);
+	Local<Value> DecodeArguments(DBusMessage *message);
 }
 
 #endif

--- a/src/object_handler.cc
+++ b/src/object_handler.cc
@@ -37,9 +37,9 @@ namespace ObjectHandler {
 		Nan::SetInternalFieldPointer(message_object, 1, message);
 
 		// Getting arguments
-		Handle<Value> arguments = Decoder::DecodeArguments(message);
+		Local<Value> arguments = Decoder::DecodeArguments(message);
 
-		Handle<Value> info[] = {
+		Local<Value> info[] = {
 			Nan::New<String>(dbus_bus_get_unique_name(connection)).ToLocalChecked(),
 			Nan::New<String>(sender).ToLocalChecked(),
 			Nan::New<String>(object_path).ToLocalChecked(),

--- a/src/signal.cc
+++ b/src/signal.cc
@@ -18,7 +18,7 @@ namespace Signal {
 	bool hookSignal = false;
 	Nan::Persistent<Function> handler;
 
-	void DispatchSignal(Handle<Value> info[])
+	void DispatchSignal(Local<Value> info[])
 	{
 		Nan::HandleScope scope;
 


### PR DESCRIPTION
use `Local<Value>` rather than `Handle<Value>` where appropriate

fixes a build breakage using nan 2.1.0 and nodejs v0.10.x

tested against nodejs v0.10.29 & v0.12.2

fixes #108 