### PR TITLE
Always add the value as argument for the property setter.

### DIFF
--- a/lib/service_interface.js
+++ b/lib/service_interface.js
@@ -130,9 +130,7 @@ ServiceInterface.prototype.setProperty = function(propName, value, callback) {
 		return false;
 	}
 
-	var args = [];
-	if (prop['in'])
-		args.push(value);
+	var args = [value];
 
 	args.push(function() {
 		// Completed


### PR DESCRIPTION
I think the if is not necessary because prop['in'] is never set for properties.