### PR TITLE
Fix DispatchSignal symbol not found when loading the module

### DIFF
--- a/src/connection.cc
+++ b/src/connection.cc
@@ -225,12 +225,12 @@ namespace Connection {
 		Nan::HandleScope scope;
 
 		// Getting arguments of signal
-		Handle<Value> arguments = Decoder::DecodeArguments(message);
+		Local<Value> arguments = Decoder::DecodeArguments(message);
 		Local<Value> senderValue = Nan::Null();
 		if (sender)
 			senderValue = Nan::New<String>(sender).ToLocalChecked();
 
-		Handle<Value> info[] = {
+		Local<Value> info[] = {
 			Nan::New<String>(dbus_bus_get_unique_name(connection)).ToLocalChecked(),
 			senderValue,
 			Nan::New<String>(object_path).ToLocalChecked(),

--- a/src/dbus.cc
+++ b/src/dbus.cc
@@ -268,14 +268,16 @@ namespace NodeDBus {
 		if (!info[0]->IsString()) {
 			info.GetReturnValue().Set(Nan::Null());
 		}
+		else {
 
-		char *src = strdup(*String::Utf8Value(info[0]->ToString()));
+			char *src = strdup(*String::Utf8Value(info[0]->ToString()));
 
-		Local<Value> obj = Introspect::CreateObject(src);
+			Local<Value> obj = Introspect::CreateObject(src);
 
-		dbus_free(src);
+			dbus_free(src);
 
-		info.GetReturnValue().Set(obj);
+			info.GetReturnValue().Set(obj);
+		}
 	}
 
 	NAN_METHOD(AddSignalFilter) {

--- a/src/dbus.cc
+++ b/src/dbus.cc
@@ -171,7 +171,7 @@ namespace NodeDBus {
 			DBusMessageIter iter;
 			DBusSignatureIter siter;
 
-			Handle<Array> argument_arr = Local<Array>::Cast(info[7]);
+			Local<Array> argument_arr = Local<Array>::Cast(info[7]);
 			if (argument_arr->Length() > 0) {
 
 				// Initializing augument message
@@ -187,7 +187,7 @@ namespace NodeDBus {
 				dbus_signature_iter_init(&siter, sig);
 				for (unsigned int i = 0; i < argument_arr->Length(); ++i) {
 					char *arg_sig = dbus_signature_iter_get_signature(&siter);
-					Handle<Value> arg = argument_arr->Get(i);
+					Local<Value> arg = argument_arr->Get(i);
 
 					if (!Encoder::EncodeObject(arg, &iter, arg_sig)) {
 						dbus_free(arg_sig);

--- a/src/dbus.cc
+++ b/src/dbus.cc
@@ -66,7 +66,6 @@ namespace NodeDBus {
 	}
 
 	NAN_METHOD(GetBus) {
-		Nan::HandleScope scope;
 		DBusConnection *connection = NULL;
 		DBusError error;
 
@@ -114,8 +113,6 @@ namespace NodeDBus {
 	}
 
 	NAN_METHOD(ReleaseBus) {
-		Nan::HandleScope scope;
-
 		Local<Object> bus_object = info[0]->ToObject();
 		//BusObject *bus = static_cast<BusObject *>(External::Unwrap(bus_object->GetInternalField(0)));
 		BusObject *bus = static_cast<BusObject *>(Nan::GetInternalFieldPointer(bus_object, 0));
@@ -127,7 +124,6 @@ namespace NodeDBus {
 	}
 
 	NAN_METHOD(CallMethod) {
-		Nan::HandleScope scope;
 		DBusError error;
 
 		if (!info[8]->IsFunction())
@@ -240,8 +236,6 @@ namespace NodeDBus {
 	}
 
 	NAN_METHOD(RequestName) {
-		Nan::HandleScope scope;
-
 		if (!info[0]->IsObject()) {
 			return Nan::ThrowTypeError("First argument must be an object (bus)");
 		}
@@ -263,8 +257,6 @@ namespace NodeDBus {
 	}
 
 	NAN_METHOD(ParseIntrospectSource) {
-		Nan::HandleScope scope;
-
 		if (!info[0]->IsString()) {
 			info.GetReturnValue().Set(Nan::Null());
 		}
@@ -281,7 +273,6 @@ namespace NodeDBus {
 	}
 
 	NAN_METHOD(AddSignalFilter) {
-		Nan::HandleScope scope;
 		DBusError error;
 
 		Local<Object> bus_object = info[0]->ToObject();
@@ -307,8 +298,6 @@ namespace NodeDBus {
 	}
 
 	NAN_METHOD(SetMaxMessageSize) {
-		Nan::HandleScope scope;
-
 		Local<Object> bus_object = info[0]->ToObject();
 
 		BusObject *bus = static_cast<BusObject *>(Nan::GetInternalFieldPointer(bus_object, 0));

--- a/src/dbus.cc
+++ b/src/dbus.cc
@@ -308,7 +308,7 @@ namespace NodeDBus {
 		return;
 	}
 
-	static void init(Handle<Object> exports) {
+	static void init(Local<Object> exports) {
 		Nan::SetMethod(exports, "getBus", GetBus);
 		Nan::SetMethod(exports, "releaseBus", ReleaseBus);
 		Nan::SetMethod(exports, "callMethod", CallMethod);

--- a/src/dbus.h
+++ b/src/dbus.h
@@ -44,7 +44,7 @@ namespace NodeDBus {
 		std::string interface;
 	} InterfaceObject;
 
-	void EmitSignal(Handle<Value> info);
+	void EmitSignal(Local<Value> info);
 }
 
 #endif

--- a/src/decoder.cc
+++ b/src/decoder.cc
@@ -76,13 +76,13 @@ namespace Decoder {
 
 				// Getting key
 				sig = dbus_message_iter_get_signature(&dict_entry_iter);
-				Handle<Value> key = DecodeMessageIter(&dict_entry_iter, sig);
+				Local<Value> key = DecodeMessageIter(&dict_entry_iter, sig);
 				dbus_free(sig);
 				if (key->IsUndefined())
 					continue;
 
 				// Try to get next element
-				Handle<Value> value;
+				Local<Value> value;
 				if (dbus_message_iter_next(&dict_entry_iter)) {
 					// Getting value
 					sig = dbus_message_iter_get_signature(&dict_entry_iter);
@@ -138,13 +138,13 @@ namespace Decoder {
 
 					// Getting key
 					sig = dbus_message_iter_get_signature(&dict_entry_iter);
-					Handle<Value> key = DecodeMessageIter(&dict_entry_iter, sig);
+					Local<Value> key = DecodeMessageIter(&dict_entry_iter, sig);
 					dbus_free(sig);
 					if (key->IsUndefined())
 						continue;
 
 					// Try to get next element
-					Handle<Value> value;
+					Local<Value> value;
 					if (dbus_message_iter_next(&dict_entry_iter)) {
 						// Getting value
 						sig = dbus_message_iter_get_signature(&dict_entry_iter);
@@ -172,7 +172,7 @@ namespace Decoder {
 
 				// Getting element
 				sig = dbus_message_iter_get_signature(&internal_iter);
-				Handle<Value> value = DecodeMessageIter(&internal_iter, sig);
+				Local<Value> value = DecodeMessageIter(&internal_iter, sig);
 				dbus_free(sig);
 				if (value->IsUndefined())
 					continue;
@@ -266,7 +266,7 @@ namespace Decoder {
 
 		do {
 			signature = dbus_message_iter_get_signature(&iter);
-			Handle<Value> value = DecodeMessageIter(&iter, signature);
+			Local<Value> value = DecodeMessageIter(&iter, signature);
 			dbus_free(signature);
 			if (value->IsUndefined())
 				continue;

--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -14,7 +14,7 @@ namespace Encoder {
 	using namespace v8;
 	using namespace std;
 
-	bool IsByte(Handle<Value> value)
+	bool IsByte(Local<Value> value)
 	{
 		if(value->IsUint32()) {
 			int number = value->Int32Value();
@@ -25,7 +25,7 @@ namespace Encoder {
 		return false;
 	}
 
-	const char *GetSignatureFromV8Type(Handle<Value>& value)
+	const char *GetSignatureFromV8Type(Local<Value>& value)
 	{
 		if (value->IsTrue() || value->IsFalse() || value->IsBoolean() ) {
 			return const_cast<char*>(DBUS_TYPE_BOOLEAN_AS_STRING);
@@ -51,7 +51,7 @@ namespace Encoder {
 		}
 	}
 
-	bool EncodeObject(Handle<Value> value, DBusMessageIter *iter, const char *signature)
+	bool EncodeObject(Local<Value> value, DBusMessageIter *iter, const char *signature)
 	{
 		// printf("EncodeObject %s\n",signature);
 		// printf("%p", value);
@@ -234,7 +234,7 @@ namespace Encoder {
 
 				dbus_free(array_sig);
 
-				Handle<Object> value_object = value->ToObject();
+				Local<Object> value_object = value->ToObject();
 				DBusSignatureIter dictSubSiter;
 
 				// Getting sub-signature object
@@ -243,7 +243,7 @@ namespace Encoder {
 				char *sig = dbus_signature_iter_get_signature(&dictSubSiter);
 
 				// process each elements
-				Handle<Array> prop_names = value_object->GetPropertyNames();
+				Local<Array> prop_names = value_object->GetPropertyNames();
 				unsigned int len = prop_names->Length();
 
 				bool failed = false;
@@ -258,8 +258,8 @@ namespace Encoder {
 					}
 
 					// Getting the key and value
-					Handle<Value> prop_key = prop_names->Get(i);
-					Handle<Value> prop_value = value_object->Get(prop_key);
+					Local<Value> prop_key = prop_names->Get(i);
+					Local<Value> prop_value = value_object->Get(prop_key);
 
 					// Append the key
 					char *prop_key_str = strdup(*String::Utf8Value(prop_key->ToString()));
@@ -293,7 +293,7 @@ namespace Encoder {
 			}
 
 			// process each elements
-			Handle<Array> arrayData = Handle<Array>::Cast(value);
+			Local<Array> arrayData = Local<Array>::Cast(value);
 			for (unsigned int i = 0; i < arrayData->Length(); ++i) {
 				Local<Value> arrayItem = arrayData->Get(i);
 				if (!EncodeObject(arrayItem, &subIter, array_sig))
@@ -338,20 +338,20 @@ namespace Encoder {
 				return false; 
 			}
 
-			Handle<Object> value_object = value->ToObject();
+			Local<Object> value_object = value->ToObject();
 
 			// Getting sub-signature object
 			dbus_signature_iter_recurse(&siter, &structSiter);
 
 			// process each elements
-			Handle<Array> prop_names = value_object->GetPropertyNames();
+			Local<Array> prop_names = value_object->GetPropertyNames();
 			unsigned int len = prop_names->Length();
 
 			for (unsigned int i = 0; i < len; ++i) {
 
 				char *sig = dbus_signature_iter_get_signature(&structSiter);
 
-				Handle<Value> prop_key = prop_names->Get(i);
+				Local<Value> prop_key = prop_names->Get(i);
 
 				if (!EncodeObject(value_object->Get(prop_key), &subIter, sig)) {
 					dbus_free(sig);

--- a/src/encoder.h
+++ b/src/encoder.h
@@ -8,7 +8,7 @@ namespace Encoder {
 	using namespace std;
 
 	const char *GetSignatureFromV8Type(Local<Value>& value);
-	bool EncodeObject(Handle<Value> value, DBusMessageIter *iter, const char *signature);
+	bool EncodeObject(Local<Value> value, DBusMessageIter *iter, const char *signature);
 }
 
 #endif

--- a/src/object_handler.cc
+++ b/src/object_handler.cc
@@ -97,8 +97,6 @@ namespace ObjectHandler {
 	DBusObjectPathVTable vtable = CreateVTable();
 
 	NAN_METHOD(RegisterObjectPath) {
-		Nan::HandleScope scope;
-
 		if (!info[0]->IsObject()) {
 			return Nan::ThrowTypeError("First parameter must be an object (bus)");
 		}
@@ -125,8 +123,6 @@ namespace ObjectHandler {
 	}
 
 	NAN_METHOD(SendMessageReply) {
-		Nan::HandleScope scope;
-
 		if (!info[0]->IsObject()) {
 			return Nan::ThrowTypeError("First parameter must be an object");
 		}
@@ -146,8 +142,6 @@ namespace ObjectHandler {
 	}
 
 	NAN_METHOD(SendErrorMessageReply) {
-		Nan::HandleScope scope;
-
 		if (!info[0]->IsObject()) {
 			return Nan::ThrowTypeError("First parameter must be an object");
 		}
@@ -175,8 +169,6 @@ namespace ObjectHandler {
 	}
 
 	NAN_METHOD(SetObjectHandler) {
-		Nan::HandleScope scope;
-
 		if (!info[0]->IsFunction()) {
 			return Nan::ThrowTypeError("First parameter must be a function");
 		}

--- a/src/signal.cc
+++ b/src/signal.cc
@@ -30,8 +30,6 @@ namespace Signal {
 	}
 
 	NAN_METHOD(SetSignalHandler) {
-		Nan::HandleScope scope;
-
 //		handler.Dispose();
 //		handler.Clear();
 
@@ -43,8 +41,6 @@ namespace Signal {
 	}
 
 	NAN_METHOD(EmitSignal) {
-		Nan::HandleScope scope;
-
 		if (!info[0]->IsObject()) {
 			return Nan::ThrowTypeError("First parameter must be an object");
 		}

--- a/src/signal.h
+++ b/src/signal.h
@@ -7,7 +7,7 @@ namespace Signal {
 	using namespace v8;
 	using namespace std;
 
-	void DispatchSignal(Handle<Value> info[]);
+	void DispatchSignal(Local<Value> info[]);
 	NAN_METHOD(EmitSignal);
 	NAN_METHOD(SetSignalHandler);
 }


### PR DESCRIPTION
Fix DispatchSignal symbol not found when loading the module. The declaration in src/signal.h and the implementation of the DispatchSignal method in src/signal.cc, so the symbol could not be found.
Remove usage of the deprecated v8::Handle class.
Remove uneeded HandleScope.