### PR TITLE
Fixes lost singals when dbus service restarts

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -34,7 +34,7 @@ var Bus = module.exports = function(dbus, busName) {
 			return;
 		}
 
-		var signalHash = sender + ':' + objectPath + ':' + interfaceName;
+		var signalHash = objectPath + ':' + interfaceName;
 
 		if (self.signalHandlers[signalHash]) {
 			var args = [ signalName ].concat(args);
@@ -74,7 +74,6 @@ Bus.prototype.reconnect = function(callback) {
 	for (var hash in self.interfaces) {
 		var iface = self.interfaces[hash];
 
-		self.dbus.addSignalFilter(self, iface.interfaceName);
 		self.registerSignalHandler(iface.serviceName, iface.objectPath, iface.interfaceName, iface);
 	}
 
@@ -153,11 +152,11 @@ Bus.prototype.registerSignalHandler = function(serviceName, objectPath, interfac
 
 	self.getUniqueServiceName(serviceName, function (err, uniqueName) {
 		// Make a hash
-		var signalHash = uniqueName + ':' + objectPath + ':' + interfaceName;
+		var signalHash = objectPath + ':' + interfaceName;
 		self.signalHandlers[signalHash] = interfaceObj;
 
 		// Register interface signal handler
-		self.dbus.addSignalFilter(self, objectPath, interfaceName, callback);
+		self.dbus.addSignalFilter(self, serviceName, objectPath, interfaceName, callback);
 	});
 };
 

--- a/lib/dbus.js
+++ b/lib/dbus.js
@@ -73,7 +73,7 @@ DBus.prototype.enableSignal = function() {
 	}
 };
 
-DBus.prototype.addSignalFilter = function(bus, objectPath, interfaceName, callback) {
+DBus.prototype.addSignalFilter = function(bus, sender, objectPath, interfaceName, callback) {
 
 	// Initializing signal if it wasn't enabled before
 	if (!bus.signalEnable) {
@@ -81,7 +81,7 @@ DBus.prototype.addSignalFilter = function(bus, objectPath, interfaceName, callba
 		_dbus.addSignalFilter(bus.connection, 'type=\'signal\'');
 	}
 
-	_dbus.addSignalFilter(bus.connection, 'type=\'signal\',interface=\'' + interfaceName + '\',path=\'' + objectPath + '\'');
+	_dbus.addSignalFilter(bus.connection, 'type=\'signal\',sender=\'' + sender + '\',interface=\'' + interfaceName + '\',path=\'' + objectPath + '\'');
 
 	process.nextTick(function() {
 		if (callback)


### PR DESCRIPTION
I have fixed the following in this PR:
- Adds service name when registering for signal.
- Removes sender unique name comparison from signal hash.
- Removes unused call to add signal interface.
 
Closes issue #113 