### PR TITLE
encoder: fix arrays of same item type

### DIFF
--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -57,7 +57,8 @@ namespace Encoder {
 					if (i == (arrayDataLength - 1))
 						return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_BOOLEAN_AS_STRING);
 				}
-			} else if (IsByte(lastArrayItem)) {
+			}
+			if (IsByte(lastArrayItem)) {
 				for (unsigned int i = 0; i < arrayDataLength; ++i) {
 					Local<Value> arrayItem = arrayData->Get(i);
 					if (!IsByte(arrayItem))
@@ -65,7 +66,8 @@ namespace Encoder {
 					if (i == (arrayDataLength - 1))
 						return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_BYTE_AS_STRING);
 				}
-			} else if (lastArrayItem->IsUint32()) {
+			}
+			if (lastArrayItem->IsUint32()) {
 				for (unsigned int i = 0; i < arrayDataLength; ++i) {
 					Local<Value> arrayItem = arrayData->Get(i);
 					if (!arrayItem->IsUint32())
@@ -73,7 +75,8 @@ namespace Encoder {
 					if (i == (arrayDataLength - 1))
 						return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_UINT32_AS_STRING);
 				}
-			} else if (lastArrayItem->IsInt32()) {
+			}
+			if (lastArrayItem->IsInt32()) {
 				for (unsigned int i = 0; i < arrayDataLength; ++i) {
 					Local<Value> arrayItem = arrayData->Get(i);
 					if (!arrayItem->IsInt32())
@@ -81,7 +84,8 @@ namespace Encoder {
 					if (i == (arrayDataLength - 1))
 						return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_INT32_AS_STRING);
 				}
-			} else if (lastArrayItem->IsNumber()) {
+			}
+			if (lastArrayItem->IsNumber()) {
 				for (unsigned int i = 0; i < arrayDataLength; ++i) {
 					Local<Value> arrayItem = arrayData->Get(i);
 					if (!arrayItem->IsNumber())
@@ -89,7 +93,8 @@ namespace Encoder {
 					if (i == (arrayDataLength - 1))
 						return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_DOUBLE_AS_STRING);
 				}
-			} else if (lastArrayItem->IsString()) {
+			}
+			if (lastArrayItem->IsString()) {
 				for (unsigned int i = 0; i < arrayDataLength; ++i) {
 					Local<Value> arrayItem = arrayData->Get(i);
 					if (!arrayItem->IsString())

--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -103,6 +103,28 @@ namespace Encoder {
 						return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_STRING_AS_STRING);
 				}
 			}
+			if (lastArrayItem->IsArray()) {
+				for (unsigned int i = 0; i < arrayDataLength; ++i) {
+					Local<Value> arrayItem = arrayData->Get(i);
+					if (!arrayItem->IsArray())
+						break;
+					if (i == (arrayDataLength - 1))
+						return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_ARRAY_AS_STRING
+							DBUS_TYPE_VARIANT_AS_STRING);
+				}
+			}
+			if (lastArrayItem->IsObject()) {
+				for (unsigned int i = 0; i < arrayDataLength; ++i) {
+					Local<Value> arrayItem = arrayData->Get(i);
+					if (!arrayItem->IsObject())
+						break;
+					if (i == (arrayDataLength - 1))
+						return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_ARRAY_AS_STRING
+							DBUS_DICT_ENTRY_BEGIN_CHAR_AS_STRING
+							DBUS_TYPE_STRING_AS_STRING DBUS_TYPE_VARIANT_AS_STRING
+							DBUS_DICT_ENTRY_END_CHAR_AS_STRING);
+				}
+			}
 			return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_VARIANT_AS_STRING);
 		} else if (value->IsObject()) {
 			return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING

--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -42,58 +42,59 @@ namespace Encoder {
 		} else if (value->IsArray()) {
 
 			Local<Array> arrayData = Local<Array>::Cast(value);
+			size_t arrayDataLength = arrayData->Length();
 
-			if (arrayData->Length() == 0)
+			if (arrayDataLength == 0)
 				return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_VARIANT_AS_STRING);
 
-			Local<Value> lastArrayItem = arrayData->Get(arrayData->Length() - 1);
+			Local<Value> lastArrayItem = arrayData->Get(arrayDataLength - 1);
 
 			if (lastArrayItem->IsTrue() || lastArrayItem->IsFalse() || lastArrayItem->IsBoolean()) {
-				for (unsigned int i = 0; i < arrayData->Length(); ++i) {
+				for (unsigned int i = 0; i < arrayDataLength; ++i) {
 					Local<Value> arrayItem = arrayData->Get(i);
 					if (!arrayItem->IsTrue() && !arrayItem->IsFalse() && !arrayItem->IsBoolean())
 						break;
-					if (i == (arrayData->Length() - 1))
+					if (i == (arrayDataLength - 1))
 						return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_BOOLEAN_AS_STRING);
 				}
 			} else if (IsByte(lastArrayItem)) {
-				for (unsigned int i = 0; i < arrayData->Length(); ++i) {
+				for (unsigned int i = 0; i < arrayDataLength; ++i) {
 					Local<Value> arrayItem = arrayData->Get(i);
 					if (!IsByte(arrayItem))
 						break;
-					if (i == (arrayData->Length() - 1))
+					if (i == (arrayDataLength - 1))
 						return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_BYTE_AS_STRING);
 				}
 			} else if (lastArrayItem->IsUint32()) {
-				for (unsigned int i = 0; i < arrayData->Length(); ++i) {
+				for (unsigned int i = 0; i < arrayDataLength; ++i) {
 					Local<Value> arrayItem = arrayData->Get(i);
 					if (!arrayItem->IsUint32())
 						break;
-					if (i == (arrayData->Length() - 1))
+					if (i == (arrayDataLength - 1))
 						return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_UINT32_AS_STRING);
 				}
 			} else if (lastArrayItem->IsInt32()) {
-				for (unsigned int i = 0; i < arrayData->Length(); ++i) {
+				for (unsigned int i = 0; i < arrayDataLength; ++i) {
 					Local<Value> arrayItem = arrayData->Get(i);
 					if (!arrayItem->IsInt32())
 						break;
-					if (i == (arrayData->Length() - 1))
+					if (i == (arrayDataLength - 1))
 						return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_INT32_AS_STRING);
 				}
 			} else if (lastArrayItem->IsNumber()) {
-				for (unsigned int i = 0; i < arrayData->Length(); ++i) {
+				for (unsigned int i = 0; i < arrayDataLength; ++i) {
 					Local<Value> arrayItem = arrayData->Get(i);
 					if (!arrayItem->IsNumber())
 						break;
-					if (i == (arrayData->Length() - 1))
+					if (i == (arrayDataLength - 1))
 						return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_DOUBLE_AS_STRING);
 				}
 			} else if (lastArrayItem->IsString()) {
-				for (unsigned int i = 0; i < arrayData->Length(); ++i) {
+				for (unsigned int i = 0; i < arrayDataLength; ++i) {
 					Local<Value> arrayItem = arrayData->Get(i);
 					if (!arrayItem->IsString())
 						break;
-					if (i == (arrayData->Length() - 1))
+					if (i == (arrayDataLength - 1))
 						return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_STRING_AS_STRING);
 				}
 			}

--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -42,13 +42,61 @@ namespace Encoder {
 		} else if (value->IsArray()) {
 
 			Local<Array> arrayData = Local<Array>::Cast(value);
-			for (unsigned int i = 0; i < arrayData->Length(); ++i) {
-				if (!arrayData->Get(i)->IsString())
-					break;
-				if (i == (arrayData->Length() - 1))
-					return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_STRING_AS_STRING);
-			}
 
+			if (arrayData->Length() == 0)
+				return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_VARIANT_AS_STRING);
+
+			Local<Value> firstArrayItem = arrayData->Get(0);
+
+			if (firstArrayItem->IsTrue() || firstArrayItem->IsFalse() || firstArrayItem->IsBoolean()) {
+				for (unsigned int i = 0; i < arrayData->Length(); ++i) {
+					Local<Value> arrayItem = arrayData->Get(i);
+					if (!arrayItem->IsTrue() && !arrayItem->IsFalse() && !arrayItem->IsBoolean())
+						break;
+					if (i == (arrayData->Length() - 1))
+						return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_BOOLEAN_AS_STRING);
+				}
+			} else if (IsByte(firstArrayItem)) {
+				for (unsigned int i = 0; i < arrayData->Length(); ++i) {
+					Local<Value> arrayItem = arrayData->Get(i);
+					if (!IsByte(arrayItem))
+						break;
+					if (i == (arrayData->Length() - 1))
+						return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_BYTE_AS_STRING);
+				}
+			} else if (firstArrayItem->IsUint32()) {
+				for (unsigned int i = 0; i < arrayData->Length(); ++i) {
+					Local<Value> arrayItem = arrayData->Get(i);
+					if (!arrayItem->IsUint32())
+						break;
+					if (i == (arrayData->Length() - 1))
+						return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_UINT32_AS_STRING);
+				}
+			} else if (firstArrayItem->IsInt32()) {
+				for (unsigned int i = 0; i < arrayData->Length(); ++i) {
+					Local<Value> arrayItem = arrayData->Get(i);
+					if (!arrayItem->IsInt32())
+						break;
+					if (i == (arrayData->Length() - 1))
+						return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_INT32_AS_STRING);
+				}
+			} else if (firstArrayItem->IsNumber()) {
+				for (unsigned int i = 0; i < arrayData->Length(); ++i) {
+					Local<Value> arrayItem = arrayData->Get(i);
+					if (!arrayItem->IsNumber())
+						break;
+					if (i == (arrayData->Length() - 1))
+						return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_DOUBLE_AS_STRING);
+				}
+			} else if (firstArrayItem->IsString()) {
+				for (unsigned int i = 0; i < arrayData->Length(); ++i) {
+					Local<Value> arrayItem = arrayData->Get(i);
+					if (!arrayItem->IsString())
+						break;
+					if (i == (arrayData->Length() - 1))
+						return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_STRING_AS_STRING);
+				}
+			}
 			return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_VARIANT_AS_STRING);
 		} else if (value->IsObject()) {
 			return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING

--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -313,7 +313,7 @@ namespace Encoder {
 			const char *var_sig = GetSignatureFromV8Type(value);
 
 			if (!dbus_message_iter_open_container(iter, DBUS_TYPE_VARIANT, var_sig, &subIter)) {
-				printf("Can't open contianer for VARIANT type\n");
+				printf("Can't open container for VARIANT type\n");
 				return false;
 			}
 

--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -46,9 +46,9 @@ namespace Encoder {
 			if (arrayData->Length() == 0)
 				return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_VARIANT_AS_STRING);
 
-			Local<Value> firstArrayItem = arrayData->Get(0);
+			Local<Value> lastArrayItem = arrayData->Get(arrayData->Length() - 1);
 
-			if (firstArrayItem->IsTrue() || firstArrayItem->IsFalse() || firstArrayItem->IsBoolean()) {
+			if (lastArrayItem->IsTrue() || lastArrayItem->IsFalse() || lastArrayItem->IsBoolean()) {
 				for (unsigned int i = 0; i < arrayData->Length(); ++i) {
 					Local<Value> arrayItem = arrayData->Get(i);
 					if (!arrayItem->IsTrue() && !arrayItem->IsFalse() && !arrayItem->IsBoolean())
@@ -56,7 +56,7 @@ namespace Encoder {
 					if (i == (arrayData->Length() - 1))
 						return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_BOOLEAN_AS_STRING);
 				}
-			} else if (IsByte(firstArrayItem)) {
+			} else if (IsByte(lastArrayItem)) {
 				for (unsigned int i = 0; i < arrayData->Length(); ++i) {
 					Local<Value> arrayItem = arrayData->Get(i);
 					if (!IsByte(arrayItem))
@@ -64,7 +64,7 @@ namespace Encoder {
 					if (i == (arrayData->Length() - 1))
 						return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_BYTE_AS_STRING);
 				}
-			} else if (firstArrayItem->IsUint32()) {
+			} else if (lastArrayItem->IsUint32()) {
 				for (unsigned int i = 0; i < arrayData->Length(); ++i) {
 					Local<Value> arrayItem = arrayData->Get(i);
 					if (!arrayItem->IsUint32())
@@ -72,7 +72,7 @@ namespace Encoder {
 					if (i == (arrayData->Length() - 1))
 						return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_UINT32_AS_STRING);
 				}
-			} else if (firstArrayItem->IsInt32()) {
+			} else if (lastArrayItem->IsInt32()) {
 				for (unsigned int i = 0; i < arrayData->Length(); ++i) {
 					Local<Value> arrayItem = arrayData->Get(i);
 					if (!arrayItem->IsInt32())
@@ -80,7 +80,7 @@ namespace Encoder {
 					if (i == (arrayData->Length() - 1))
 						return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_INT32_AS_STRING);
 				}
-			} else if (firstArrayItem->IsNumber()) {
+			} else if (lastArrayItem->IsNumber()) {
 				for (unsigned int i = 0; i < arrayData->Length(); ++i) {
 					Local<Value> arrayItem = arrayData->Get(i);
 					if (!arrayItem->IsNumber())
@@ -88,7 +88,7 @@ namespace Encoder {
 					if (i == (arrayData->Length() - 1))
 						return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_DOUBLE_AS_STRING);
 				}
-			} else if (firstArrayItem->IsString()) {
+			} else if (lastArrayItem->IsString()) {
 				for (unsigned int i = 0; i < arrayData->Length(); ++i) {
 					Local<Value> arrayItem = arrayData->Get(i);
 					if (!arrayItem->IsString())

--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -40,6 +40,15 @@ namespace Encoder {
 		} else if (value->IsString()) {
 			return const_cast<char*>(DBUS_TYPE_STRING_AS_STRING);
 		} else if (value->IsArray()) {
+
+			Local<Array> arrayData = Local<Array>::Cast(value);
+			for (unsigned int i = 0; i < arrayData->Length(); ++i) {
+				if (!arrayData->Get(i)->IsString())
+					break;
+				if (i == (arrayData->Length() - 1))
+					return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_STRING_AS_STRING);
+			}
+
 			return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_VARIANT_AS_STRING);
 		} else if (value->IsObject()) {
 			return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING


### PR DESCRIPTION
encoder: fix arrays of items of the same type

As described in https://github.com/Shouqun/node-dbus/issues/120

A javascript array is always handled as an array of variant.

This steps through an array to confirm that all elements are of the same type,
then produces a dbus structure accordingly, now supporting:

* array of boolean
* array of byte
* array of uint32
* array of int32
* array of double
* array of string
* array of array (variant)
* array of object

and defaulting to array of variant otherwise.

Please note:  The function tries the above data types in exactly the above order, just as node-dbus already does for its data type detection.  For example, if all of the elements pass for `byte`, then they will be passed as an `array of byte`.  If one of the elements do not pass as a `byte`, then it will be passed as an `array of uint32` or `array of int32` accordingly.

This is no different from the current behavior of node-dbus.  If you pass it a 1 from javascript, it will be parsed as a byte.  Passing 300, or -1 from javascript will be parsed as integers.

closes #120 