### PR TITLE
encoder: refactor array handling to reuse common code

### DIFF
--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -79,19 +79,19 @@ typedef bool (*CheckTypeCallback) (Local<Value>& value);
 		if (IsByte(value)) {
 			return const_cast<char*>(DBUS_TYPE_BYTE_AS_STRING);
 		}
-		if (value->IsUint32()) {
+		if (IsUint32(value)) {
 			return const_cast<char*>(DBUS_TYPE_UINT32_AS_STRING);
 		}
-		if (value->IsInt32()) {
+		if (IsInt32(value)) {
 			return const_cast<char*>(DBUS_TYPE_INT32_AS_STRING);
 		}
-		if (value->IsNumber()) {
+		if (IsNumber(value)) {
 			return const_cast<char*>(DBUS_TYPE_DOUBLE_AS_STRING);
 		}
-		if (value->IsString()) {
+		if (IsString(value)) {
 			return const_cast<char*>(DBUS_TYPE_STRING_AS_STRING);
 		}
-		if (value->IsArray()) {
+		if (IsArray(value)) {
 
 			Local<Array> arrayData = Local<Array>::Cast(value);
 
@@ -128,7 +128,7 @@ typedef bool (*CheckTypeCallback) (Local<Value>& value);
 			}
 			return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_VARIANT_AS_STRING);
 		}
-		if (value->IsObject()) {
+		if (IsObject(value)) {
 			return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING
 				DBUS_DICT_ENTRY_BEGIN_CHAR_AS_STRING
 				DBUS_TYPE_STRING_AS_STRING DBUS_TYPE_VARIANT_AS_STRING

--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -73,7 +73,7 @@ typedef bool (*CheckTypeCallback) (Local<Value>& value);
 
 	const char *GetSignatureFromV8Type(Local<Value>& value)
 	{
-		if (value->IsTrue() || value->IsFalse() || value->IsBoolean() ) {
+		if (IsBoolean(value)) {
 			return const_cast<char*>(DBUS_TYPE_BOOLEAN_AS_STRING);
 		}
 		if (IsByte(value)) {

--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -14,7 +14,7 @@ namespace Encoder {
 	using namespace v8;
 	using namespace std;
 
-	bool IsByte(Local<Value> value)
+	bool IsByte(Local<Value>& value)
 	{
 		if(value->IsUint32()) {
 			int number = value->Int32Value();

--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -75,17 +75,23 @@ typedef bool (*CheckTypeCallback) (Local<Value>& value);
 	{
 		if (value->IsTrue() || value->IsFalse() || value->IsBoolean() ) {
 			return const_cast<char*>(DBUS_TYPE_BOOLEAN_AS_STRING);
-		} else if (IsByte(value)) {
+		}
+		if (IsByte(value)) {
 			return const_cast<char*>(DBUS_TYPE_BYTE_AS_STRING);
-		} else if (value->IsUint32()) {
+		}
+		if (value->IsUint32()) {
 			return const_cast<char*>(DBUS_TYPE_UINT32_AS_STRING);
-		} else if (value->IsInt32()) {
+		}
+		if (value->IsInt32()) {
 			return const_cast<char*>(DBUS_TYPE_INT32_AS_STRING);
-		} else if (value->IsNumber()) {
+		}
+		if (value->IsNumber()) {
 			return const_cast<char*>(DBUS_TYPE_DOUBLE_AS_STRING);
-		} else if (value->IsString()) {
+		}
+		if (value->IsString()) {
 			return const_cast<char*>(DBUS_TYPE_STRING_AS_STRING);
-		} else if (value->IsArray()) {
+		}
+		if (value->IsArray()) {
 
 			Local<Array> arrayData = Local<Array>::Cast(value);
 
@@ -121,14 +127,14 @@ typedef bool (*CheckTypeCallback) (Local<Value>& value);
 					DBUS_DICT_ENTRY_END_CHAR_AS_STRING);
 			}
 			return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_VARIANT_AS_STRING);
-		} else if (value->IsObject()) {
+		}
+		if (value->IsObject()) {
 			return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING
 				DBUS_DICT_ENTRY_BEGIN_CHAR_AS_STRING
 				DBUS_TYPE_STRING_AS_STRING DBUS_TYPE_VARIANT_AS_STRING
 				DBUS_DICT_ENTRY_END_CHAR_AS_STRING);
-		} else {
-			return NULL;
 		}
+		return NULL;
 	}
 
 	bool EncodeObject(Local<Value> value, DBusMessageIter *iter, const char *signature)


### PR DESCRIPTION
Please merge these changes to clean up the code that was added to fix the marshaling of arrays with items of the same type #121 as described in #120 

