### PR TITLE
encoder: fix marshalling of nested arrays

### DIFF
--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -71,7 +71,7 @@ typedef bool (*CheckTypeCallback) (Local<Value>& value);
 		return true;
 	}
 
-	const char *GetSignatureFromV8Type(Local<Value>& value)
+	string GetSignatureFromV8Type(Local<Value>& value)
 	{
 		if (IsBoolean(value)) {
 			return const_cast<char*>(DBUS_TYPE_BOOLEAN_AS_STRING);
@@ -134,7 +134,7 @@ typedef bool (*CheckTypeCallback) (Local<Value>& value);
 				DBUS_TYPE_STRING_AS_STRING DBUS_TYPE_VARIANT_AS_STRING
 				DBUS_DICT_ENTRY_END_CHAR_AS_STRING);
 		}
-		return NULL;
+		return "";
 	}
 
 	bool EncodeObject(Local<Value> value, DBusMessageIter *iter, const char *signature)
@@ -396,7 +396,8 @@ typedef bool (*CheckTypeCallback) (Local<Value>& value);
 		{
 			DBusMessageIter subIter;
 
-			const char *var_sig = GetSignatureFromV8Type(value);
+			string str_sig = GetSignatureFromV8Type(value);
+			const char *var_sig = str_sig.c_str();
 
 			if (!dbus_message_iter_open_container(iter, DBUS_TYPE_VARIANT, var_sig, &subIter)) {
 				printf("Can't open container for VARIANT type\n");

--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -117,6 +117,20 @@ typedef bool (*CheckTypeCallback) (Local<Value>& value);
 				return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_STRING_AS_STRING);
 			}
 			if (CheckArrayItems(arrayData, IsArray)) {
+
+				Local<Value> lastArrayItem = arrayData->Get(arrayData->Length() - 1);
+				string lastArrayItemSig = GetSignatureFromV8Type(lastArrayItem);
+
+				for (unsigned int i = 0; i < arrayData->Length(); ++i) {
+					Local<Value> arrayItem = arrayData->Get(i);
+
+					string sig = GetSignatureFromV8Type(arrayItem);
+
+					if (0 != sig.compare(lastArrayItemSig))
+						break;
+					if (i == (arrayData->Length() - 1))
+						return string(const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING)).append(sig);
+				}
 				return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_ARRAY_AS_STRING
 					DBUS_TYPE_VARIANT_AS_STRING);
 			}

--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -62,7 +62,7 @@ namespace Encoder {
 
 	bool HasSameSig(Local<Value>& value, const char* sig = NULL)
 	{
-		return (NULL != sig) && (strlen(sig)) &&
+		return (sig) && (strlen(sig)) &&
 			(0 == GetSignatureFromV8Type(value).compare(sig));
 	}
 

--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -94,8 +94,9 @@ typedef bool (*CheckTypeCallback) (Local<Value>& value);
 		if (IsArray(value)) {
 
 			Local<Array> arrayData = Local<Array>::Cast(value);
+			size_t arrayDataLength = arrayData->Length();
 
-			if (arrayData->Length() == 0) {
+			if (0 == arrayDataLength) {
 				return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_VARIANT_AS_STRING);
 			}
 			if (CheckArrayItems(arrayData, IsBoolean)) {
@@ -118,17 +119,17 @@ typedef bool (*CheckTypeCallback) (Local<Value>& value);
 			}
 			if (CheckArrayItems(arrayData, IsArray)) {
 
-				Local<Value> lastArrayItem = arrayData->Get(arrayData->Length() - 1);
+				Local<Value> lastArrayItem = arrayData->Get(arrayDataLength - 1);
 				string lastArrayItemSig = GetSignatureFromV8Type(lastArrayItem);
 
-				for (unsigned int i = 0; i < arrayData->Length(); ++i) {
+				for (unsigned int i = 0; i < arrayDataLength; ++i) {
 					Local<Value> arrayItem = arrayData->Get(i);
 
 					string sig = GetSignatureFromV8Type(arrayItem);
 
 					if (0 != sig.compare(lastArrayItemSig))
 						break;
-					if (i == (arrayData->Length() - 1))
+					if (i == (arrayDataLength - 1))
 						return string(const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING)).append(sig);
 				}
 				return const_cast<char*>(DBUS_TYPE_ARRAY_AS_STRING DBUS_TYPE_ARRAY_AS_STRING

--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -62,7 +62,8 @@ namespace Encoder {
 
 	bool HasSameSig(Local<Value>& value, const char* sig = NULL)
 	{
-		return (NULL != sig) && (0 == GetSignatureFromV8Type(value).compare(sig));
+		return (NULL != sig) && (strlen(sig)) &&
+			(0 == GetSignatureFromV8Type(value).compare(sig));
 	}
 
 typedef bool (*CheckTypeCallback) (Local<Value>& value, const char* sig);

--- a/src/encoder.h
+++ b/src/encoder.h
@@ -7,7 +7,7 @@ namespace Encoder {
 	using namespace v8;
 	using namespace std;
 
-	const char *GetSignatureFromV8Type(Local<Value>& value);
+	string GetSignatureFromV8Type(Local<Value>& value);
 	bool EncodeObject(Local<Value> value, DBusMessageIter *iter, const char *signature);
 }
 


### PR DESCRIPTION
In the spirit of #120 , this fixes the handling of the case of `nested arrays` where each internal array contains items all of the same type by allowing the function `GetSignatureFromV8Type` to call itself recursively.

For example, when encoding the following:
```
[ [ [ 'X', 'Y' ], [ 'a', 'bb', 'ccc' ] ],
  [ [ 'X', 'Y' ], [ 'a', 'bb', 'ccc' ] ],
  [ [ 'X', 'Y' ], [ 'a', 'bb', 'ccc' ] ] ]
```
build `0.2.18` returns:
```
   variant       array [
         array [
            variant                array [
                  string "X"
                  string "Y"
               ]
            variant                array [
                  string "a"
                  string "bb"
                  string "ccc"
               ]
         ]
         array [
            variant                array [
                  string "X"
                  string "Y"
               ]
            variant                array [
                  string "a"
                  string "bb"
                  string "ccc"
               ]
         ]
         array [
            variant                array [
                  string "X"
                  string "Y"
               ]
            variant                array [
                  string "a"
                  string "bb"
                  string "ccc"
               ]
         ]
      ]
```

after these fixes, it will now return:

```
   variant       array [
         array [
            array [
               string "X"
               string "Y"
            ]
            array [
               string "a"
               string "bb"
               string "ccc"
            ]
         ]
         array [
            array [
               string "X"
               string "Y"
            ]
            array [
               string "a"
               string "bb"
               string "ccc"
            ]
         ]
         array [
            array [
               string "X"
               string "Y"
            ]
            array [
               string "a"
               string "bb"
               string "ccc"
            ]
         ]
      ]
```

closes #124 