### PR TITLE
Use the correct variable type when parsing message

### DIFF
--- a/src/decoder.cc
+++ b/src/decoder.cc
@@ -26,32 +26,23 @@ namespace Decoder {
 
 		// Get type of current value
 		switch(cur_type) {
-		case DBUS_TYPE_BOOLEAN:
-		{
-			dbus_bool_t value = false;
-			dbus_message_iter_get_basic(iter, &value);
-			return scope.Escape(Nan::New<Boolean>(value));
+#define DBUS_BASIC_TYPE(arg_type, dbus_type, def_val, v8_type) \
+		case arg_type: \
+		{ \
+			dbus_type value = def_val; \
+			dbus_message_iter_get_basic(iter, &value); \
+			return scope.Escape(Nan::New<v8_type>(value)); \
 		}
-
-		case DBUS_TYPE_BYTE:
-		case DBUS_TYPE_INT16:
-		case DBUS_TYPE_UINT16:
-		case DBUS_TYPE_INT32:
-		case DBUS_TYPE_UINT32:
-		case DBUS_TYPE_INT64:
-		case DBUS_TYPE_UINT64:
-		{
-			dbus_uint64_t value = 0;
-			dbus_message_iter_get_basic(iter, &value);
-			return scope.Escape(Nan::New<Number>(value));
-		}
-
-		case DBUS_TYPE_DOUBLE: 
-		{
-			double value = 0;
-			dbus_message_iter_get_basic(iter, &value);
-			return scope.Escape(Nan::New<Number>(value));
-		}
+		DBUS_BASIC_TYPE(DBUS_TYPE_BOOLEAN, dbus_bool_t, false, Boolean)
+		DBUS_BASIC_TYPE(DBUS_TYPE_BYTE, unsigned char, 0, Number)
+		DBUS_BASIC_TYPE(DBUS_TYPE_INT16, dbus_int16_t, 0, Number)
+		DBUS_BASIC_TYPE(DBUS_TYPE_UINT16, dbus_uint16_t, 0, Number)
+		DBUS_BASIC_TYPE(DBUS_TYPE_INT32, dbus_int32_t, 0, Number)
+		DBUS_BASIC_TYPE(DBUS_TYPE_UINT32, dbus_uint32_t, 0, Number)
+		DBUS_BASIC_TYPE(DBUS_TYPE_INT64, dbus_int64_t, 0, Number)
+		DBUS_BASIC_TYPE(DBUS_TYPE_UINT64, dbus_uint64_t, 0, Number)
+		DBUS_BASIC_TYPE(DBUS_TYPE_DOUBLE, double, 0, Number)
+#undef DBUS_BASIC_TYPE
 
 		case DBUS_TYPE_OBJECT_PATH:
 		case DBUS_TYPE_SIGNATURE:


### PR DESCRIPTION
This is especially important when dealing with signed vs. unsigned types.