### PR TITLE
Allow for building on MacOS X 10.12.2 with MacPorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ or equivalent for your system
 
 **Node-gyp**  
 `$ npm install -g node-gyp`  
-[https://www.npmjs.com/package/node-gyp](https://www.npmjs.com/package/node-gyp)
+[https://www.npmjs.com/package/node-gyp](https://www.npmjs.com/package/node-gyp)	
 
 **libdbus**  
 `$ sudo port install dbus`

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ $ npm install dbus
 To build, do: `node-gyp configure build` or `npm install`.
 
 ## Dependencies
+
+### General
+
 **Node-gyp**  
 `$ npm install -g node-gyp`  
 [https://www.npmjs.com/package/node-gyp](https://www.npmjs.com/package/node-gyp)
@@ -25,6 +28,19 @@ or equivalent for your system
 **glib2.0**  
 `$ sudo apt-get install libglib2.0-dev`  
 or equivalent for your system
+
+### MacOS with MacPorts
+
+**Node-gyp**  
+`$ npm install -g node-gyp`  
+[https://www.npmjs.com/package/node-gyp](https://www.npmjs.com/package/node-gyp)
+
+**libdbus**  
+`$ sudo port install dbus`
+
+**glib2.0**  
+`$ sudo port install glib2`
+
 
 ## Getting Started
 Best way to get started is by looking at the examples. After the build:

--- a/binding.gyp
+++ b/binding.gyp
@@ -12,7 +12,9 @@
         'src/object_handler.cc'
       ],
       'include_dirs': [
-        "<!(node -e \"require('nan')\")"
+        "<!(node -e \"require('nan')\")",
+        "/opt/local/include/dbus-1.0",
+        "/opt/local/lib/dbus-1.0/include"
       ],
       'dependencies': [
         'deps/libexpat/libexpat.gyp:expat'

--- a/binding.gyp
+++ b/binding.gyp
@@ -12,9 +12,7 @@
         'src/object_handler.cc'
       ],
       'include_dirs': [
-        "<!(node -e \"require('nan')\")",
-        "/opt/local/include/dbus-1.0",
-        "/opt/local/lib/dbus-1.0/include"
+        "<!(node -e \"require('nan')\")"
       ],
       'dependencies': [
         'deps/libexpat/libexpat.gyp:expat'
@@ -34,6 +32,13 @@
           'libraries': [
             '<!@(pkg-config  --libs-only-l --libs-only-other dbus-1)'
           ]
+        }],
+        ['OS=="mac"', {
+          'include_dirs': [
+            "/opt/local/include/dbus-1.0",
+            "/opt/local/lib/dbus-1.0/include",
+            "/usr/local/opt"
+          ],
         }]
       ]
     }


### PR DESCRIPTION
Fixes issue #144, allowing node-dbus to built on MacOS X.

Tested with latest dbus installed via MacPorts 2.3.5, on MacOS X 10.12.2, and node 6.7.0.