### PR TITLE
Allow child paths to be introspectable

### DIFF
--- a/lib/service_object.js
+++ b/lib/service_object.js
@@ -93,6 +93,7 @@ ServiceObject.prototype.createInterface = function(interfaceName) {
 
 ServiceObject.prototype.updateIntrospection = function() {
 	var self = this;
+	var i;
 
 	var introspection = [
 		'<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"',
@@ -105,7 +106,42 @@ ServiceObject.prototype.updateIntrospection = function() {
 		introspection.push(iface.introspection);
 	}
 
+	var childNodes = self.buildChildNodes();
+
+	for (i = 0; i < childNodes.length; i++) {
+		introspection.push('<node name="' + childNodes[i] + '"/>');
+	}
 	introspection.push('</node>');
 
 	self.introspection = introspection.join('\n');
+};
+
+ServiceObject.prototype.buildChildNodes = function() {
+	var self = this;
+
+	function unique(arr) {
+		var t = {};
+		var i;
+		for (i = 0; i < arr.length; i++) {
+			t[arr[i]] = true;
+		}
+
+		return Object.keys(t);
+	}
+
+	var prefix = self.path + '/';
+	var allKeys = Object.keys(self.service.objects);
+	var childKeys = allKeys.filter(function(key) {
+		return key.substr(0, prefix.length) == prefix
+		    && key.length > prefix.length;
+	});
+	var unprefixedChildKeys = childKeys.map(function(key) {
+		return key.substr(prefix.length);
+	});
+	var childNodes = unprefixedChildKeys.map(function(key) {
+		return key.split('/')[0];
+	});
+	var uniqueChildNodes = unique(childNodes);
+
+	return uniqueChildNodes;
 };


### PR DESCRIPTION
Add `<node name="[child_path]"/>` to the introspection XML for all
potential child paths that have already been defined. This makes it
possible to find the children of a path using tools like `busctl tree`.

Fixes #149