### PR TITLE
Add basic tests against dbus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 *.o
 *.swp
 *.node
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
 
 before_install:
   - sudo apt-get -qq update
+  - sudo apt-get install -y dbus
   - sudo apt-get install -y libdbus-1-dev
   - sudo apt-get install -y libglib2.0-dev
 
@@ -25,3 +26,5 @@ addons:
     - gcc-4.8
 
 before_script: npm install -g standard
+
+script: dbus-launch -- npm test

--- a/lib/.travis.yml
+++ b/lib/.travis.yml
@@ -1,4 +1,0 @@
-language: node_js
-node_js:
-  - 0.4
-  - 0.6

--- a/package.json
+++ b/package.json
@@ -16,10 +16,16 @@
   },
   "main": "./lib/dbus",
   "scripts": {
-    "install": "node-gyp configure build"
+    "install": "node-gyp configure build",
+    "test": "tap test/**/*.test.js"
   },
   "dependencies": {
     "nan": "^2.1.0"
   },
-  "os": ["!win32"]
+  "os": [
+    "!win32"
+  ],
+  "devDependencies": {
+    "tap": "^10.0.2"
+  }
 }

--- a/test/client-call-add.test.js
+++ b/test/client-call-add.test.js
@@ -10,11 +10,11 @@ withService(function(err, done) {
 	var bus = dbus.getBus('session');
 
 	bus.getInterface('test.dbus.TestService', '/test/dbus/TestService', 'test.dbus.TestService.Interface1', function(err, iface) {
-		iface.Ping.timeout = 1000;
-		iface.Ping.finish = function(result) {
-			tap.equal(result, 'Pong!');
+		iface.Add.timeout = 1000;
+		iface.Add.finish = function(result) {
+			tap.equal(result, 310);
 			done();
 		};
-		iface.Ping();
+		iface.Add(109, 201);
 	});
 });

--- a/test/client-call-noargs.test.js
+++ b/test/client-call-noargs.test.js
@@ -1,0 +1,20 @@
+var withService = require('./with-service');
+var tap = require('tap');
+var DBus = require('../');
+
+tap.plan(1);
+withService(function(err, done) {
+	if (err) throw err;
+
+	var dbus = new DBus();
+	var bus = dbus.getBus('session');
+
+	bus.getInterface('test.dbus.TestService', '/test/dbus/TestService', 'test.dbus.TestService.Interface1', function(err, iface) {
+		iface.NoArgs.timeout = 1000;
+		iface.NoArgs.finish = function(result) {
+			tap.equal(result, 'result!');
+			done();
+		};
+		iface.NoArgs();
+	});
+});

--- a/test/client-call-timeout.test.js
+++ b/test/client-call-timeout.test.js
@@ -1,0 +1,24 @@
+var withService = require('./with-service');
+var tap = require('tap');
+var DBus = require('../');
+
+tap.plan(1);
+withService(function(err, done) {
+	if (err) throw err;
+
+	var dbus = new DBus();
+	var bus = dbus.getBus('session');
+
+	bus.getInterface('test.dbus.TestService', '/test/dbus/TestService', 'test.dbus.TestService.Interface1', function(err, iface) {
+		iface.LongProcess.timeout = 1000;
+		iface.LongProcess.finish = function(result) {
+			tap.fail('This should not have succeeded');
+			done();
+		};
+		iface.LongProcess.error = function(err) {
+			tap.pass('The call timed out as expected');
+			done();
+		};
+		iface.LongProcess();
+	});
+});

--- a/test/client-call.test.js
+++ b/test/client-call.test.js
@@ -1,0 +1,20 @@
+var withService = require('./with-service');
+var tap = require('tap');
+var DBus = require('../');
+
+tap.plan(1);
+withService(function(err, done) {
+	if (err) throw err;
+
+	var dbus = new DBus();
+	var bus = dbus.getBus('session');
+
+	bus.getInterface('test.dbus.TestService', '/test/dbus/TestService', 'test.dbus.TestService.Interface1', function(err, iface) {
+		iface.Ping.timeout = 1000;
+		iface.Ping.finish = function(result) {
+			tap.equal(result, 'Pong!');
+			done();
+		};
+		iface.Ping();
+	});
+});

--- a/test/client-property.test.js
+++ b/test/client-property.test.js
@@ -1,0 +1,33 @@
+var withService = require('./with-service');
+var tap = require('tap');
+var DBus = require('../');
+
+tap.plan(5);
+withService(function(err, done) {
+	if (err) throw err;
+
+	var dbus = new DBus();
+	var bus = dbus.getBus('session');
+
+	bus.getInterface('test.dbus.TestService', '/test/dbus/TestService', 'test.dbus.TestService.Interface1', function(err, iface) {
+		iface.getProperty('Author', function(err, value) {
+			tap.equal(value, 'Fred Chien');
+
+			iface.setProperty('Author', 'Douglas Adams', function(err) {
+				iface.getProperty('Author', function(err, value) {
+					tap.equal(value, 'Douglas Adams');
+
+					iface.getProperty('URL', function(err, value) {
+						tap.equal(value, 'http://stem.mandice.org');
+
+						iface.getProperties(function(err, props) {
+							tap.equal(props.Author, 'Douglas Adams');
+							tap.equal(props.URL, 'http://stem.mandice.org');
+							done();
+						});
+					});
+				});
+			}); 
+		});
+	});
+});

--- a/test/client-signal.test.js
+++ b/test/client-signal.test.js
@@ -1,0 +1,18 @@
+var withService = require('./with-service');
+var tap = require('tap');
+var DBus = require('../');
+
+tap.plan(1);
+withService(function(err, done) {
+	if (err) throw err;
+
+	var dbus = new DBus();
+	var bus = dbus.getBus('session');
+
+	bus.getInterface('test.dbus.TestService', '/test/dbus/TestService', 'test.dbus.TestService.Interface1', function(err, iface) {
+		iface.on('pump', function() {
+			tap.pass('Signal received');
+			done();
+		});
+	});
+});

--- a/test/service.js
+++ b/test/service.js
@@ -1,0 +1,64 @@
+var DBus = require('../');
+
+var dbus = new DBus();
+
+// Create a new service, object and interface
+var service = dbus.registerService('session', 'test.dbus.TestService');
+var obj = service.createObject('/test/dbus/TestService');
+
+// Create interface
+
+var iface1 = obj.createInterface('test.dbus.TestService.Interface1');
+
+iface1.addMethod('Ping', { out: DBus.Define(String) }, function(callback) {
+	callback('Pong!');
+});
+
+var author = 'Fred Chien';
+iface1.addProperty('Author', {
+	type: DBus.Define(String),
+	getter: function(callback) {
+		callback(author);
+	},
+	setter: function(value, complete) {
+		author = value;
+
+		complete();
+	}
+});
+
+// Read-only property
+var url = 'http://stem.mandice.org';
+iface1.addProperty('URL', {
+	type: DBus.Define(String),
+	getter: function(callback) {
+		callback(url);
+	}
+});
+
+// Signal
+var counter = 0;
+iface1.addSignal('pump', {
+	types: [
+		DBus.Define(Number)
+	]
+});
+
+iface1.update();
+
+// Emit signal per one second
+setInterval(function() {
+	counter++;
+	iface1.emit('pump', counter);
+}, 1000);
+
+// Create second interface
+var iface2 = obj.createInterface('test.dbus.TestService.Interface2');
+
+iface2.addMethod('Hello', { out: DBus.Define(String) }, function(callback) {
+	callback('Hello There!');
+});
+
+iface2.update();
+
+process.send({ message: 'ready' });

--- a/test/service.js
+++ b/test/service.js
@@ -10,8 +10,18 @@ var obj = service.createObject('/test/dbus/TestService');
 
 var iface1 = obj.createInterface('test.dbus.TestService.Interface1');
 
-iface1.addMethod('Ping', { out: DBus.Define(String) }, function(callback) {
-	callback('Pong!');
+iface1.addMethod('NoArgs', { out: DBus.Define(String) }, function(callback) {
+	callback('result!');
+});
+
+iface1.addMethod('Add', { in: [DBus.Define(Number), DBus.Define(Number)], out: DBus.Define(Number) }, function(n1, n2, callback) {
+	callback(n1 + n2);
+});
+
+iface1.addMethod('LongProcess', { out: DBus.Define(Number) }, function(callback) {
+	setTimeout(function() {
+		callback(0);
+	}, 5000);
 });
 
 var author = 'Fred Chien';

--- a/test/with-service.js
+++ b/test/with-service.js
@@ -1,0 +1,31 @@
+var child_process = require('child_process');
+var path = require('path');
+
+function withService(callback) {
+	// Start a new process with our service code.
+	var p = child_process.fork(path.join(__dirname, 'service.js'));
+
+	var done = function() {
+		p.kill();
+	}
+
+	done.process = p;
+
+	p.on('message', function(m) {
+		// When the service process has started and notifies us that it
+		// is ready, we call the callback so that the test code can
+		// proceed.
+		callback(null, done);
+	});
+
+	p.on('exit', function() {
+		// Because there is no way to shut down a connection, the node
+		// process keeps running after we're done with our testing. The
+		// way we handle this, then, is that when a test is done using
+		// the service, we kill the process that we started. And once
+		// that process has exited, we kill the current process.
+		process.exit();
+	});
+}
+
+module.exports = withService;


### PR DESCRIPTION
Based on the .travis.yml, it looks like this project supports back to Node 0.12.

While doing the work for pull request #150, I used `Object.keys`. However, I was unsure whether this was a supported call in Node 0.12. Because the Travis-CI build only tests whether the C++ code builds propertly, and doesn't test any of the JS code, the results of the Travis-CI build doesn't prevent code that would break in Node 0.12 from getting committed.

So, this commit adds some basic tests (cribbed mostly from the examples folder) that run a service and a client against an actual dbus daemon to test that the code can do basic things like call methods, get and set properties, and receive signals.

The way this is done is that, each test file (`test/*.test.js`) spawns a DBus Service (`test/service.js`) and then executes client commands against that service.