### PR TITLE
Use node conventions for asynchronous calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 *.o
 *.swp
 *.node
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
 
 before_install:
   - sudo apt-get -qq update
+  - sudo apt-get install -y dbus
   - sudo apt-get install -y libdbus-1-dev
   - sudo apt-get install -y libglib2.0-dev
 
@@ -25,3 +26,5 @@ addons:
     - gcc-4.8
 
 before_script: npm install -g standard
+
+script: dbus-launch -- npm test

--- a/examples/error_handling.js
+++ b/examples/error_handling.js
@@ -6,13 +6,12 @@ var bus = dbus.getBus('session');
 
 bus.getInterface('nodejs.dbus.ExampleService', '/nodejs/dbus/ExampleService', 'nodejs.dbus.ExampleService.Interface1', function(err, iface) {
 
-	iface.MakeError['timeout'] = 1000;
-	iface.MakeError['error'] = function(err) {
-		console.log(err);
-	};
-	iface.MakeError['finish'] = function(result) {
-		console.log(result);
-	};
-	iface.MakeError();
+	iface.MakeError({ timeout: 1000 }, function(err, result) {
+		if (err) {
+			console.log(err);
+			return;
+		}
 
+		console.log(result);
+	});
 });

--- a/examples/hello.js
+++ b/examples/hello.js
@@ -6,10 +6,11 @@ var bus = dbus.getBus('session');
 
 bus.getInterface('nodejs.dbus.ExampleService', '/nodejs/dbus/ExampleService', 'nodejs.dbus.ExampleService.Interface1', function(err, iface) {
 
-	iface.Hello['timeout'] = 1000;
-	iface.Hello['finish'] = function(result) {
-		console.log(result);
-	};
-	iface.Hello();
+	iface.Hello({ timeout: 1000 }, function(err, result) {
+		if (err) {
+			return console.log(err);
+		}
 
+		console.log(result);
+	});
 });

--- a/examples/invalid_args.js
+++ b/examples/invalid_args.js
@@ -5,14 +5,11 @@ var dbus = new DBus();
 var bus = dbus.getBus('session');
 
 bus.getInterface('nodejs.dbus.ExampleService', '/nodejs/dbus/ExampleService', 'nodejs.dbus.ExampleService.Interface1', function(err, iface) {
+	iface.Equal({ timeout: 1000 }, function(err, result) {
+		if (err) {
+			return console.log(err);
+		}
 
-	iface.Equal['timeout'] = 1000;
-	iface.Equal['error'] = function(err) {
-		console.log(err);
-	};
-	iface.Equal['finish'] = function(result) {
 		console.log(result);
-	};
-	iface.Equal();
-
+	});
 });

--- a/examples/method.js
+++ b/examples/method.js
@@ -6,36 +6,33 @@ var bus = dbus.getBus('session');
 
 bus.getInterface('nodejs.dbus.ExampleService', '/nodejs/dbus/ExampleService', 'nodejs.dbus.ExampleService.Interface1', function(err, iface) {
 
-	iface.SendObject['timeout'] = 1000;
-	iface.SendObject['finish'] = function(result) {
-		console.log(result);
-	};
-
 	iface.SendObject({
 		name: 'Fred',
 		email: 'cfsghost@gmail.com'
+	}, { timeout: 1000 }, function(err, result) {
+		console.log(result);
 	});
 
 	// Blank object
-	iface.SendObject({});
+	iface.SendObject({}, { timeout: 1000 }, function(err, result) {
+	});
 
 	// Testing method with no return value
-	iface.Dummy['timeout'] = 1000;
-	iface.Dummy['finish'] = function() {
+	iface.Dummy({ timeout: 1000 }, function(err) {
 		console.log('Dummy');
-	};
-	iface.Dummy();
+	});
 
 	// Testing method with complex dictionary object
-	iface.GetContacts['timeout'] = 1000;
-	iface.GetContacts['finish'] = function(contacts) {
+	iface.GetContacts({ timeout: 1000 }, function(err, contacts) {
 		console.log(contacts);
-	};
-	iface.GetContacts();
+	});
 
 	// Error handling
-	iface.SendObject['finish'] = function(ret) {
-		console.log(ret);
-	};
-	iface.SendObject('Wrong arguments');
+	iface.SendObject('Wrong arguments', function(err, result) {
+		if (err) {
+			return console.log(err);
+		}
+
+		console.log(result);
+	});
 });

--- a/examples/multi_connection.js
+++ b/examples/multi_connection.js
@@ -6,11 +6,9 @@ var bus1 = dbus.getBus('session');
 
 bus1.getInterface('nodejs.dbus.ExampleService', '/nodejs/dbus/ExampleService', 'nodejs.dbus.ExampleService.Interface1', function(err, iface) {
 
-	iface.Hello['timeout'] = 1000;
-	iface.Hello['finish'] = function(result) {
+	iface.Hello({ timeout: 1000 }, function(result) {
 		console.log(result);
-	};
-	iface.Hello();
+	});
 
 });
 
@@ -18,11 +16,9 @@ var bus2 = dbus.getBus('session');
 
 bus2.getInterface('nodejs.dbus.ExampleService', '/nodejs/dbus/ExampleService', 'nodejs.dbus.ExampleService.Interface1', function(err, iface) {
 
-	iface.Hello['timeout'] = 1000;
-	iface.Hello['finish'] = function(result) {
+	iface.Hello({ timeout: 1000 }, function(result) {
 		console.log(result);
-	};
-	iface.Hello();
+	});
 
 });
 

--- a/lib/.travis.yml
+++ b/lib/.travis.yml
@@ -1,4 +1,0 @@
-language: node_js
-node_js:
-  - 0.4
-  - 0.6

--- a/lib/interface.js
+++ b/lib/interface.js
@@ -24,8 +24,26 @@ Interface.prototype.init = function(callback) {
 		self[methodName] = (function(method, signature) {
 
 			return function() {
-				var args = Array.prototype.slice.call(arguments);
-				var timeout = this[method].timeout || -1;
+				var allArgs = Array.prototype.slice.call(arguments);
+				var interfaceIn = self.object.method[method].in;
+				var dbusArgs = allArgs.slice(0, interfaceIn.length);
+				var restArgs = allArgs.slice(interfaceIn.length);
+				var options = restArgs[0];
+				var callback = restArgs[1];
+
+				if (typeof options === 'function') {
+					// No options were specified; only a callback.
+					callback = options;
+					options = {};
+				}
+
+				if (!options) {
+					options = {};
+				}
+				if (!callback) {
+					callback = function() {};
+				}
+				var timeout = options.timeout || -1;
 				var handler = this[method].finish || null
 				var error = this[method].error || null
 
@@ -39,29 +57,12 @@ Interface.prototype.init = function(callback) {
 							method,
 							signature,
 							timeout,
-							args,
-							function(err, result) {
-
-								if (err)
-									return error ? error(err) : null;
-
-								if (handler) {
-									handler(result);
-									handler = null;
-								}
-							});
+							dbusArgs,
+							callback);
 					} catch(e) {
-						if (error) {
-							error(e);
-							error = null;
-						}
+						callback(e);
 					}
 				});
-
-				this[method].timeout = -1;
-				this[method].finish = null;
-				this[method].error = null;
-
 			};
 		})(methodName, self.object['method'][methodName]['in'].join('') || '');
 		self[methodName].timeout = -1;

--- a/package.json
+++ b/package.json
@@ -16,10 +16,16 @@
   },
   "main": "./lib/dbus",
   "scripts": {
-    "install": "node-gyp configure build"
+    "install": "node-gyp configure build",
+    "test": "tap test/**/*.test.js"
   },
   "dependencies": {
     "nan": "^2.1.0"
   },
-  "os": ["!win32"]
+  "os": [
+    "!win32"
+  ],
+  "devDependencies": {
+    "tap": "^10.0.2"
+  }
 }

--- a/test/client-call-add.test.js
+++ b/test/client-call-add.test.js
@@ -1,0 +1,20 @@
+var withService = require('./with-service');
+var tap = require('tap');
+var DBus = require('../');
+
+tap.plan(1);
+withService(function(err, done) {
+	if (err) throw err;
+
+	var dbus = new DBus();
+	var bus = dbus.getBus('session');
+
+	bus.getInterface('test.dbus.TestService', '/test/dbus/TestService', 'test.dbus.TestService.Interface1', function(err, iface) {
+		iface.Add.timeout = 1000;
+		iface.Add.finish = function(result) {
+			tap.equal(result, 310);
+			done();
+		};
+		iface.Add(109, 201);
+	});
+});

--- a/test/client-call-add.test.js
+++ b/test/client-call-add.test.js
@@ -2,7 +2,7 @@ var withService = require('./with-service');
 var tap = require('tap');
 var DBus = require('../');
 
-tap.plan(1);
+tap.plan(2);
 withService(function(err, done) {
 	if (err) throw err;
 
@@ -10,11 +10,15 @@ withService(function(err, done) {
 	var bus = dbus.getBus('session');
 
 	bus.getInterface('test.dbus.TestService', '/test/dbus/TestService', 'test.dbus.TestService.Interface1', function(err, iface) {
-		iface.Add.timeout = 1000;
-		iface.Add.finish = function(result) {
+		// With options
+		iface.Add(109, 201, { timeout: 1000 }, function(err, result) {
 			tap.equal(result, 310);
-			done();
-		};
-		iface.Add(109, 201);
+
+			// Without options
+			iface.Add(109, 201, function(err, result) {
+				tap.equal(result, 310);
+				done();
+			});
+		});
 	});
 });

--- a/test/client-call-noargs.test.js
+++ b/test/client-call-noargs.test.js
@@ -1,0 +1,20 @@
+var withService = require('./with-service');
+var tap = require('tap');
+var DBus = require('../');
+
+tap.plan(1);
+withService(function(err, done) {
+	if (err) throw err;
+
+	var dbus = new DBus();
+	var bus = dbus.getBus('session');
+
+	bus.getInterface('test.dbus.TestService', '/test/dbus/TestService', 'test.dbus.TestService.Interface1', function(err, iface) {
+		iface.NoArgs.timeout = 1000;
+		iface.NoArgs.finish = function(result) {
+			tap.equal(result, 'result!');
+			done();
+		};
+		iface.NoArgs();
+	});
+});

--- a/test/client-call-noargs.test.js
+++ b/test/client-call-noargs.test.js
@@ -2,7 +2,7 @@ var withService = require('./with-service');
 var tap = require('tap');
 var DBus = require('../');
 
-tap.plan(1);
+tap.plan(2);
 withService(function(err, done) {
 	if (err) throw err;
 
@@ -10,11 +10,15 @@ withService(function(err, done) {
 	var bus = dbus.getBus('session');
 
 	bus.getInterface('test.dbus.TestService', '/test/dbus/TestService', 'test.dbus.TestService.Interface1', function(err, iface) {
-		iface.NoArgs.timeout = 1000;
-		iface.NoArgs.finish = function(result) {
+		// With options
+		iface.NoArgs({ timeout: 1000 }, function(err, result) {
 			tap.equal(result, 'result!');
-			done();
-		};
-		iface.NoArgs();
+
+			// Without options
+			iface.NoArgs(function(err, result) {
+				tap.equal(result, 'result!');
+				done();
+			});
+		});
 	});
 });

--- a/test/client-call-timeout.test.js
+++ b/test/client-call-timeout.test.js
@@ -1,0 +1,24 @@
+var withService = require('./with-service');
+var tap = require('tap');
+var DBus = require('../');
+
+tap.plan(1);
+withService(function(err, done) {
+	if (err) throw err;
+
+	var dbus = new DBus();
+	var bus = dbus.getBus('session');
+
+	bus.getInterface('test.dbus.TestService', '/test/dbus/TestService', 'test.dbus.TestService.Interface1', function(err, iface) {
+		iface.LongProcess.timeout = 1000;
+		iface.LongProcess.finish = function(result) {
+			tap.fail('This should not have succeeded');
+			done();
+		};
+		iface.LongProcess.error = function(err) {
+			tap.pass('The call timed out as expected');
+			done();
+		};
+		iface.LongProcess();
+	});
+});

--- a/test/client-call-timeout.test.js
+++ b/test/client-call-timeout.test.js
@@ -2,7 +2,7 @@ var withService = require('./with-service');
 var tap = require('tap');
 var DBus = require('../');
 
-tap.plan(1);
+tap.plan(2);
 withService(function(err, done) {
 	if (err) throw err;
 
@@ -10,15 +10,10 @@ withService(function(err, done) {
 	var bus = dbus.getBus('session');
 
 	bus.getInterface('test.dbus.TestService', '/test/dbus/TestService', 'test.dbus.TestService.Interface1', function(err, iface) {
-		iface.LongProcess.timeout = 1000;
-		iface.LongProcess.finish = function(result) {
-			tap.fail('This should not have succeeded');
+		iface.LongProcess({ timeout: 1000 }, function(err, result) {
+			tap.notSame(err, null);
+			tap.same(result, null);
 			done();
-		};
-		iface.LongProcess.error = function(err) {
-			tap.pass('The call timed out as expected');
-			done();
-		};
-		iface.LongProcess();
+		});
 	});
 });

--- a/test/client-property.test.js
+++ b/test/client-property.test.js
@@ -1,0 +1,33 @@
+var withService = require('./with-service');
+var tap = require('tap');
+var DBus = require('../');
+
+tap.plan(5);
+withService(function(err, done) {
+	if (err) throw err;
+
+	var dbus = new DBus();
+	var bus = dbus.getBus('session');
+
+	bus.getInterface('test.dbus.TestService', '/test/dbus/TestService', 'test.dbus.TestService.Interface1', function(err, iface) {
+		iface.getProperty('Author', function(err, value) {
+			tap.equal(value, 'Fred Chien');
+
+			iface.setProperty('Author', 'Douglas Adams', function(err) {
+				iface.getProperty('Author', function(err, value) {
+					tap.equal(value, 'Douglas Adams');
+
+					iface.getProperty('URL', function(err, value) {
+						tap.equal(value, 'http://stem.mandice.org');
+
+						iface.getProperties(function(err, props) {
+							tap.equal(props.Author, 'Douglas Adams');
+							tap.equal(props.URL, 'http://stem.mandice.org');
+							done();
+						});
+					});
+				});
+			}); 
+		});
+	});
+});

--- a/test/client-signal.test.js
+++ b/test/client-signal.test.js
@@ -1,0 +1,18 @@
+var withService = require('./with-service');
+var tap = require('tap');
+var DBus = require('../');
+
+tap.plan(1);
+withService(function(err, done) {
+	if (err) throw err;
+
+	var dbus = new DBus();
+	var bus = dbus.getBus('session');
+
+	bus.getInterface('test.dbus.TestService', '/test/dbus/TestService', 'test.dbus.TestService.Interface1', function(err, iface) {
+		iface.on('pump', function() {
+			tap.pass('Signal received');
+			done();
+		});
+	});
+});

--- a/test/service.js
+++ b/test/service.js
@@ -1,0 +1,74 @@
+var DBus = require('../');
+
+var dbus = new DBus();
+
+// Create a new service, object and interface
+var service = dbus.registerService('session', 'test.dbus.TestService');
+var obj = service.createObject('/test/dbus/TestService');
+
+// Create interface
+
+var iface1 = obj.createInterface('test.dbus.TestService.Interface1');
+
+iface1.addMethod('NoArgs', { out: DBus.Define(String) }, function(callback) {
+	callback('result!');
+});
+
+iface1.addMethod('Add', { in: [DBus.Define(Number), DBus.Define(Number)], out: DBus.Define(Number) }, function(n1, n2, callback) {
+	callback(n1 + n2);
+});
+
+iface1.addMethod('LongProcess', { out: DBus.Define(Number) }, function(callback) {
+	setTimeout(function() {
+		callback(0);
+	}, 5000);
+});
+
+var author = 'Fred Chien';
+iface1.addProperty('Author', {
+	type: DBus.Define(String),
+	getter: function(callback) {
+		callback(author);
+	},
+	setter: function(value, complete) {
+		author = value;
+
+		complete();
+	}
+});
+
+// Read-only property
+var url = 'http://stem.mandice.org';
+iface1.addProperty('URL', {
+	type: DBus.Define(String),
+	getter: function(callback) {
+		callback(url);
+	}
+});
+
+// Signal
+var counter = 0;
+iface1.addSignal('pump', {
+	types: [
+		DBus.Define(Number)
+	]
+});
+
+iface1.update();
+
+// Emit signal per one second
+setInterval(function() {
+	counter++;
+	iface1.emit('pump', counter);
+}, 1000);
+
+// Create second interface
+var iface2 = obj.createInterface('test.dbus.TestService.Interface2');
+
+iface2.addMethod('Hello', { out: DBus.Define(String) }, function(callback) {
+	callback('Hello There!');
+});
+
+iface2.update();
+
+process.send({ message: 'ready' });

--- a/test/with-service.js
+++ b/test/with-service.js
@@ -1,0 +1,31 @@
+var child_process = require('child_process');
+var path = require('path');
+
+function withService(callback) {
+	// Start a new process with our service code.
+	var p = child_process.fork(path.join(__dirname, 'service.js'));
+
+	var done = function() {
+		p.kill();
+	}
+
+	done.process = p;
+
+	p.on('message', function(m) {
+		// When the service process has started and notifies us that it
+		// is ready, we call the callback so that the test code can
+		// proceed.
+		callback(null, done);
+	});
+
+	p.on('exit', function() {
+		// Because there is no way to shut down a connection, the node
+		// process keeps running after we're done with our testing. The
+		// way we handle this, then, is that when a test is done using
+		// the service, we kill the process that we started. And once
+		// that process has exited, we kill the current process.
+		process.exit();
+	});
+}
+
+module.exports = withService;


### PR DESCRIPTION
Change how methods are called on an interface from

    iface.someMethod.timeout = 1000;
    iface.someMethod.error = function(err) {
    };
    iface.someMethod.finish = function(result) {
    };
    iface.someMethod(arg1, arg2);

to

    iface.someMethod(arg1, arg2, {timeout:1000}, function(err, result) {
    });

or (if the timeout is not needed, the options object can be dropped)

    iface.someMethod(arg1, arg2, function(err, result) {
    });

to be more in-line with node's error-first callback conventions around
asynchronous calls.

Fixes #86.