### PR TITLE
Add bus.disconnect and service.disconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ bus.getInterface('com.example.Library', '/com/example/Library/authors/DAdams', '
 });
 ```
 
+#### `Bus.prototype.disconnect()`
+
+Disconnect from DBus. This disconnection makes it so that Node isn't kept
+running based on this active connection. It also makes this bus, and all of its
+children (interfaces that have been retrieved, etc.) unusable.
+
 
 ### Interface
 
@@ -230,6 +236,13 @@ Remove (or unexpose) an object that has been created.
 ```
 service.removeObject(object);
 ```
+
+#### `Service.prototype.disconnect()`
+
+Disconnect from DBus. This disconnection makes it so that Node isn't kept
+running based on this active connection. It also disconnects all of the objects
+created by this service. 
+
 
 ### ServiceObject
 

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -51,6 +51,12 @@ var Bus = module.exports = function(dbus, busName) {
 
 util.inherits(Bus, events.EventEmitter);
 
+Object.defineProperty(Bus.prototype, 'connected', {
+	get: function() {
+		return this.connection !== null;
+	}
+});
+
 Bus.prototype.disconnect = function(callback) {
 	var self = this;
 
@@ -96,6 +102,13 @@ Bus.prototype.reconnect = function(callback) {
 
 Bus.prototype.introspect = function(serviceName, objectPath, callback) {
 	var self = this;
+
+	if (!self.connected) {
+		process.nextTick(function() {
+			callback(new Error('Bus is no longer connected'));
+		});
+		return;
+	}
 
 	// Getting scheme of specific object
 	self.dbus.callMethod(self.connection,

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -51,6 +51,19 @@ var Bus = module.exports = function(dbus, busName) {
 
 util.inherits(Bus, events.EventEmitter);
 
+Bus.prototype.disconnect = function(callback) {
+	var self = this;
+
+	delete self.dbus.signalHandlers[self.connection.uniqueName];
+
+	self.dbus._dbus.releaseBus(self.connection);
+
+	self.connection = null;
+
+	if (callback)
+		process.nextTick(callback);
+};
+
 Bus.prototype.reconnect = function(callback) {
 	var self = this;
 

--- a/lib/dbus.js
+++ b/lib/dbus.js
@@ -6,7 +6,6 @@ var Utils = require('./utils');
 var Bus = require('./bus');
 var Service = require('./service');
 
-var busMap = {};
 var serviceMap = {};
 
 var enabledSignal = false;
@@ -41,14 +40,7 @@ DBus.Signature = Utils.Signature;
 DBus.prototype.getBus = function(busName) {
 	var self = this;
 
-	// Return bus existed
-	if (busMap[busName])
-		return busMap[busName];
-
-	var bus = new Bus(self, busName);
-	busMap[busName] = bus;
-
-	return bus;
+	return new Bus(self, busName);
 };
 
 DBus.prototype.parseIntrospectSource = function(source) {

--- a/lib/interface.js
+++ b/lib/interface.js
@@ -15,6 +15,12 @@ var Interface = module.exports = function(bus, serviceName, objectPath, interfac
 
 util.inherits(Interface, events.EventEmitter);
 
+Object.defineProperty(Interface.prototype, 'connected', {
+	get: function() {
+		return this.bus.connected;
+	}
+});
+
 Interface.prototype.init = function(callback) {
 	var self = this;
 
@@ -48,6 +54,10 @@ Interface.prototype.init = function(callback) {
 				var error = this[method].error || null
 
 				process.nextTick(function() {
+					if (!self.connected) {
+						callback(new Error('Bus is no longer connected'));
+						return;
+					}
 
 					try {
 						self.bus.dbus.callMethod(self.bus.connection,
@@ -90,6 +100,13 @@ Interface.prototype.init = function(callback) {
 Interface.prototype.setProperty = function(propertyName, value, callback) {
 	var self = this;
 
+	if (!self.connected) {
+		process.nextTick(function() {
+			callback(new Error('Bus is no longer connected'));
+		});
+		return;
+	}
+
 	self.bus.dbus.callMethod(self.bus.connection,
 		self.serviceName,
 		self.objectPath,
@@ -108,6 +125,13 @@ Interface.prototype.setProperty = function(propertyName, value, callback) {
 Interface.prototype.getProperty = function(propertyName, callback) {
 	var self = this;
 
+	if (!self.connected) {
+		process.nextTick(function() {
+			callback(new Error('Bus is no longer connected'));
+		});
+		return;
+	}
+
 	self.bus.dbus.callMethod(self.bus.connection,
 		self.serviceName,
 		self.objectPath,
@@ -125,6 +149,13 @@ Interface.prototype.getProperty = function(propertyName, callback) {
 
 Interface.prototype.getProperties = function(callback) {
 	var self = this;
+
+	if (!self.connected) {
+		process.nextTick(function() {
+			callback(new Error('Bus is no longer connected'));
+		});
+		return;
+	}
 
 	self.bus.dbus.callMethod(self.bus.connection,
 		self.serviceName,

--- a/lib/service.js
+++ b/lib/service.js
@@ -22,6 +22,12 @@ var Service = module.exports = function(bus, serviceName) {
 
 util.inherits(Service, events.EventEmitter);
 
+Object.defineProperty(Service.prototype, 'connected', {
+	get: function() {
+		return this.bus.connected;
+	}
+});
+
 Service.prototype.createObject = function(objectPath) {
 	var self = this;
 

--- a/lib/service.js
+++ b/lib/service.js
@@ -39,3 +39,9 @@ Service.prototype.removeObject = function(object) {
 
 	self.bus.dbus._dbus.unregisterObjectPath(self.bus.connection, object.path);
 };
+
+Service.prototype.disconnect = function() {
+	var self = this;
+
+	self.bus.disconnect();
+};

--- a/lib/service_interface.js
+++ b/lib/service_interface.js
@@ -166,6 +166,11 @@ ServiceInterface.prototype.getProperties = function(callback) {
 ServiceInterface.prototype.emitSignal = function() {
 	var self = this;
 
+	var service = self.object.service;
+	if (!service.connected) {
+		throw new Error('Service is no longer connected');
+	}
+
 	var conn = self.object.service.bus.connection;
 	var objPath = self.object.path;
 	var interfaceName = self.name;

--- a/src/connection.cc
+++ b/src/connection.cc
@@ -274,9 +274,6 @@ namespace Connection {
 
 		uv_unref((uv_handle_t *)bus->loop);
 
-		if (dbus_connection_get_is_connected(connection))
-			dbus_connection_close(connection);
-
 		dbus_connection_unref(connection);
 	}
 

--- a/test/client-call-add.test.js
+++ b/test/client-call-add.test.js
@@ -18,6 +18,7 @@ withService('service.js', function(err, done) {
 			iface.Add(109, 201, function(err, result) {
 				tap.equal(result, 310);
 				done();
+				bus.disconnect();
 			});
 		});
 	});

--- a/test/client-call-noargs.test.js
+++ b/test/client-call-noargs.test.js
@@ -18,6 +18,7 @@ withService('service.js', function(err, done) {
 			iface.NoArgs(function(err, result) {
 				tap.equal(result, 'result!');
 				done();
+				bus.disconnect();
 			});
 		});
 	});

--- a/test/client-call-timeout.test.js
+++ b/test/client-call-timeout.test.js
@@ -14,6 +14,7 @@ withService('service.js', function(err, done) {
 			tap.notSame(err, null);
 			tap.same(result, null);
 			done();
+			bus.disconnect();
 		});
 	});
 });

--- a/test/client-disconnect.test.js
+++ b/test/client-disconnect.test.js
@@ -1,0 +1,16 @@
+var tap = require('tap');
+var DBus = require('../');
+
+var dbus = new DBus();
+var bus = dbus.getBus('session');
+
+tap.plan(1);
+
+var timeout = setTimeout(function() {
+	tap.fail('Should have disconnected by now');
+	process.exit();
+}, 1000);
+timeout.unref();
+
+tap.ok('This is a dummy test. The real test is whether the tap.fail gets called on the timeout.');
+bus.disconnect();

--- a/test/client-property.test.js
+++ b/test/client-property.test.js
@@ -24,6 +24,7 @@ withService('service.js', function(err, done) {
 							tap.equal(props.Author, 'Douglas Adams');
 							tap.equal(props.URL, 'http://stem.mandice.org');
 							done();
+							bus.disconnect();
 						});
 					});
 				});

--- a/test/client-signal.test.js
+++ b/test/client-signal.test.js
@@ -13,6 +13,7 @@ withService('service.js', function(err, done) {
 		iface.on('pump', function() {
 			tap.pass('Signal received');
 			done();
+			bus.disconnect();
 		});
 	});
 });

--- a/test/client-use-after-disconnect.test.js
+++ b/test/client-use-after-disconnect.test.js
@@ -1,0 +1,44 @@
+var tap = require('tap');
+var DBus = require('../');
+
+var dbus = new DBus();
+var bus = dbus.getBus('session');
+
+tap.plan(11);
+
+var timeout = setTimeout(function() {
+	tap.fail('Should have disconnected by now');
+	process.exit();
+}, 1000);
+timeout.unref();
+
+tap.ok('This is a dummy test. The real test is whether the tap.fail gets called on the timeout.');
+
+bus.getInterface('org.freedesktop.DBus', '/', 'org.freedesktop.DBus', function(err, iface) {
+	setTimeout(function() {
+		bus.disconnect();
+	}, 50);
+
+	setTimeout(function() {
+		iface.getProperty('Test', function(err, value) {
+			tap.type(err, Error);
+			tap.match(err.message, /no.*connected/, 'getProperty returns the correct error');
+		});
+		iface.setProperty('Test', 'Value', function(err) {
+			tap.type(err, Error);
+			tap.match(err.message, /no.*connected/, 'setProperty returns the correct error');
+		});
+		iface.getProperties(function(err, values) {
+			tap.type(err, Error);
+			tap.match(err.message, /no.*connected/, 'getProperties returns the correct error');
+		});
+		iface.NameHasOwner('Test', function(err, result) {
+			tap.type(err, Error);
+			tap.match(err.message, /no.*connected/, 'call returns the correct error');
+		});
+		bus.getInterface('org.freedesktop.DBus', '/obj', 'org.freedesktop.DBus', function(err, iface) {
+			tap.type(err, Error);
+			tap.match(err.message, /no.*connected/, 'getInterface returns the correct error');
+		});
+	}, 100);
+});

--- a/test/service-client-disconnect.test.js
+++ b/test/service-client-disconnect.test.js
@@ -1,0 +1,26 @@
+var tap = require('tap');
+var DBus = require('../');
+
+tap.plan(1);
+
+var dbus = new DBus();
+var client = dbus.getBus('session');
+
+var timeout = setTimeout(function() {
+	tap.fail('Should have disconnected by now');
+	process.exit();
+}, 1000);
+timeout.unref();
+
+tap.ok('This is a dummy test. The real test is whether the tap.fail gets called on the timeout.');
+setTimeout(function() {
+	client.disconnect();
+}, 50);
+
+setTimeout(function() {
+	var service = dbus.registerService('session', 'test.dbus.TestService');
+	service.createObject('/test/dbus/TestService');
+	setImmediate(function() {
+		service.disconnect();
+	});
+}, 100);

--- a/test/service-create-remove-object.test.js
+++ b/test/service-create-remove-object.test.js
@@ -22,6 +22,7 @@ withService('service-dynamic.js', function(err, done) {
 							checkInterface(bus, '2', function(err, result) {
 								tap.equal(result, false);
 								done();
+								bus.disconnect();
 							});
 						});
 					});

--- a/test/service-disconnect.test.js
+++ b/test/service-disconnect.test.js
@@ -1,0 +1,19 @@
+var tap = require('tap');
+var DBus = require('../');
+
+tap.plan(1);
+
+var dbus = new DBus();
+var service = dbus.registerService('session', 'test.dbus.TestService');
+service.createObject('/test/dbus/TestService');
+
+var timeout = setTimeout(function() {
+	tap.fail('Should have disconnected by now');
+	process.exit();
+}, 1000);
+timeout.unref();
+
+tap.ok('This is a dummy test. The real test is whether the tap.fail gets called on the timeout.');
+setTimeout(function() {
+	service.disconnect();
+}, 50);

--- a/test/service-dynamic.js
+++ b/test/service-dynamic.js
@@ -35,6 +35,10 @@ process.on('message', function(msg) {
 			process.send({ type: 'remove', value: value });
 		}
 	}
+	else if (msg.message === 'done') {
+		service.disconnect();
+		process.removeAllListeners('message');
+	}
 });
 
 process.send({ message: 'ready' });

--- a/test/service-emit-after-disconnect.test.js
+++ b/test/service-emit-after-disconnect.test.js
@@ -1,0 +1,27 @@
+var tap = require('tap');
+var DBus = require('../');
+
+tap.plan(2);
+
+var dbus = new DBus();
+var service = dbus.registerService('session', 'test.dbus.TestService');
+var object = service.createObject('/test/dbus/TestService');
+var iface = object.createInterface('test.dbus.TestService.Interface1');
+
+iface.addSignal('Test', { types: [DBus.Define(String)] });
+
+var timeout = setTimeout(function() {
+	tap.fail('Should have disconnected by now');
+	process.exit();
+}, 1000);
+timeout.unref();
+
+tap.ok('This is a dummy test. The real test is whether the tap.fail gets called on the timeout.');
+setTimeout(function() {
+	service.disconnect();
+}, 50);
+setTimeout(function() {
+	tap.throws(function() {
+		iface.emitSignal('Test', 'test');
+	}, /no.*connected/, 'Emit throws an error after disconnect');
+}, 100);

--- a/test/with-service.js
+++ b/test/with-service.js
@@ -6,7 +6,7 @@ function withService(name, callback) {
 	var p = child_process.fork(path.join(__dirname, name));
 
 	var done = function() {
-		p.kill();
+		p.send({ message: 'done' });
 	}
 
 	done.process = p;
@@ -18,15 +18,6 @@ function withService(name, callback) {
 			// proceed.
 			callback(null, done);
 		}
-	});
-
-	p.on('exit', function() {
-		// Because there is no way to shut down a connection, the node
-		// process keeps running after we're done with our testing. The
-		// way we handle this, then, is that when a test is done using
-		// the service, we kill the process that we started. And once
-		// that process has exited, we kill the current process.
-		process.exit();
 	});
 }
 


### PR DESCRIPTION
Allow applications to disconnect their connections to dbus after they are done with them.

Fixes #133

Changes required to make this happen:

* Don't share bus objects: remove the code in lib/dbus.js that stores created Bus objects and returns them when a new bus is requested. Instead, create a new Bus object whenever one is requested. This allows each Bus object to disconnect itself without worrying that other objects are relying on it being connected. Note that at the C++ level, there is connection sharing going on because of the use of `dbus_bus_get`, but that isn't a problem because the dbus library is managing the sharing, and calling `Bus.prototype.disconnect` will correctly notify the underlying C++ that that particulary Bus object is no longer using its connection.

* Remove the `dbus_connection_close` call. According to the documentation, this method should not be used when a connection is acquired using `dbus_bus_get`. Removing this prevents the error message "Applications must not close shared connections - see dbus_connection_close() docs. This is a bug in the application." noted in #133. See [dbus_bus_get][1] and [dbus_connection_close][2].

* Throw or emit node-level errors when trying to use a disconnected connection. When an operation is attempted on a closed connection, throw a Node-level error instead of allowing the C++ to surface an error. In order to do this, we keep track of whether a bus is still connected or whether it has already been disconnected. `serviceInterface.emitSignal` does not have a callback and will throw an error if the connection is already disconnected. All other methods that try to use a disconnected connection will return the error in the callback.

* Update tests to disconnect themselves, rather than relying on `process.exit` to force the tests to disconnect.

[1]: https://dbus.freedesktop.org/doc/api/html/group__DBusBus.html#ga77ba5250adb84620f16007e1b023cf26
[2]: https://dbus.freedesktop.org/doc/api/html/group__DBusConnection.html#ga2522ac5075dfe0a1535471f6e045e1ee