### PR TITLE
Error class

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,28 @@ made (via `addMethod`, `addProperty`, and `addSignal`), `update` must be called
 to ensure that other DBus clients can see the changes that were made.
 
 
+### DBus.Error
+
+A DBus-specific error
+
+#### `new DBus.Error(name, message)`
+
+* name `<string>` - A valid DBus Error name, according to the [specification][spec]
+* message `<string>` - A human readable message
+
+Create a new error. The name must be a valid error name.
+
+```
+throw new DBus.Error('com.example.Library.Error.BookExistsError', 'The book already exists');
+```
+
+#### `dbusError.dbusName`
+
+The DBus Error name of the error. When a DBus.Error is created, its message is
+set to the human-readable error message. The `dbusName` property is set to the
+name (according to the DBus Spec).
+
+
 ## License 
 
 (The MIT License)
@@ -383,3 +405,4 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+[spec]: https://dbus.freedesktop.org/doc/dbus-specification.html

--- a/examples/service.js
+++ b/examples/service.js
@@ -17,9 +17,7 @@ iface1.addMethod('Dummy', {}, function(callback) {
 });
 
 iface1.addMethod('MakeError', { out: DBus.Define(String) }, function(callback) {
-	var error = new Error('Some error');
-	error.dbusName = 'nodejs.dbus.ExampleService.ErrorTest';
-	callback(error);
+	callback(new DBus.Error('nodejs.dbus.ExampleService.ErrorTest', 'Some error'));
 });
 
 iface1.addMethod('Hello', { out: DBus.Define(String) }, function(callback) {

--- a/examples/service.js
+++ b/examples/service.js
@@ -17,7 +17,9 @@ iface1.addMethod('Dummy', {}, function(callback) {
 });
 
 iface1.addMethod('MakeError', { out: DBus.Define(String) }, function(callback) {
-	callback(new Error('nodejs.dbus.ExampleService.ErrorTest'));
+	var error = new Error('Some error');
+	error.dbusName = 'nodejs.dbus.ExampleService.ErrorTest';
+	callback(error);
 });
 
 iface1.addMethod('Hello', { out: DBus.Define(String) }, function(callback) {

--- a/lib/dbus.js
+++ b/lib/dbus.js
@@ -5,6 +5,7 @@ var _dbus = require('../build/Release/dbus.node');
 var Utils = require('./utils');
 var Bus = require('./bus');
 var Service = require('./service');
+var Error = require('./error');
 
 var serviceMap = {};
 
@@ -36,6 +37,7 @@ var DBus = module.exports = function(opts) {
 
 DBus.Define = Utils.Define;
 DBus.Signature = Utils.Signature;
+DBus.Error = Error;
 
 DBus.prototype.getBus = function(busName) {
 	var self = this;
@@ -128,9 +130,14 @@ DBus.prototype._sendErrorMessageReply = function(message, name, msg) {
 	_dbus.sendErrorMessageReply(message, name, msg);
 };
 
-DBus.prototype.callMethod = function() {
+function createError(name, message) {
+	return new DBus.Error(name, message);
+}
 
-	_dbus.callMethod.apply(this, Array.prototype.slice.call(arguments));
+DBus.prototype.callMethod = function() {
+	var args = Array.prototype.slice.call(arguments);
+	args.push(createError);
+	_dbus.callMethod.apply(this, args);
 };
 
 DBus.prototype.setMaxMessageSize = function(bus, size) {

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,0 +1,22 @@
+var util = require('util');
+
+function DBusError(name, message) {
+	Error.call(this, message);
+	this.message = message;
+	this.dbusName = name;
+
+	if (Error.captureStackTrace) {
+		Error.captureStackTrace(this, 'DBusError');
+	}
+	else {
+		Object.defineProperty(this, 'stack', { value: (new Error()).stack });
+	}
+}
+
+util.inherits(DBusError, Error);
+
+DBusError.prototype.toString = function() {
+	return 'DBusError: ' + this.message;
+}
+
+module.exports = DBusError;

--- a/lib/interface.js
+++ b/lib/interface.js
@@ -75,10 +75,6 @@ Interface.prototype.init = function(callback) {
 				});
 			};
 		})(methodName, self.object['method'][methodName]['in'].join('') || '');
-		self[methodName].timeout = -1;
-		self[methodName].finish = null;
-		self[methodName].error = null;
-
 	}
 
 	// Initializing signal handler

--- a/lib/service_interface.js
+++ b/lib/service_interface.js
@@ -95,7 +95,8 @@ ServiceInterface.prototype.call = function(method, message, args) {
 
 		// Error handling
 		if (value instanceof Error) {
-			self.object.service.bus.dbus._sendErrorMessageReply(message, value.message);
+			var name = value.dbusName || 'org.freedesktop.DBus.Error.Failed';
+			self.object.service.bus.dbus._sendErrorMessageReply(message, name, value.message);
 			return;
 		}
 

--- a/src/dbus.h
+++ b/src/dbus.h
@@ -20,8 +20,10 @@ namespace NodeDBus {
 //		Nan::Persistent<Function> callback;
 		Nan::Callback *callback;
 		DBusPendingCall *pending;
+		Nan::Callback *createError;
 
 		~DBusAsyncData() {
+			delete createError;
 			delete callback;
 		}
 	} DBusAsyncData;

--- a/test/client-call-error.test.js
+++ b/test/client-call-error.test.js
@@ -1,0 +1,29 @@
+var withService = require('./with-service');
+var tap = require('tap');
+var DBus = require('../');
+
+tap.plan(6);
+withService('service.js', function(err, done) {
+	if (err) throw err;
+
+	var dbus = new DBus();
+	var bus = dbus.getBus('session');
+
+	bus.getInterface('test.dbus.TestService', '/test/dbus/TestService', 'test.dbus.TestService.Interface1', function(err, iface) {
+		iface.ThrowsError({ timeout: 1000 }, function(err, result) {
+			tap.notSame(err, null);
+			tap.same(result, null);
+			// tap.match(err.message, /from service/);
+			tap.match(err.message, 'org.freedesktop.DBus.Error.Failed');
+
+			iface.ThrowsCustomError({ timeout: 1000 }, function(err, result) {
+				tap.notSame(err, null);
+				tap.same(result, null);
+				// tap.match(err.message, /from service/);
+				tap.match(err.message, 'test.dbus.TestService.Error');
+				done();
+				bus.disconnect();
+			});
+		});
+	});
+});

--- a/test/client-call-error.test.js
+++ b/test/client-call-error.test.js
@@ -2,7 +2,7 @@ var withService = require('./with-service');
 var tap = require('tap');
 var DBus = require('../');
 
-tap.plan(6);
+tap.plan(10);
 withService('service.js', function(err, done) {
 	if (err) throw err;
 
@@ -13,14 +13,16 @@ withService('service.js', function(err, done) {
 		iface.ThrowsError({ timeout: 1000 }, function(err, result) {
 			tap.notSame(err, null);
 			tap.same(result, null);
-			// tap.match(err.message, /from service/);
-			tap.match(err.message, 'org.freedesktop.DBus.Error.Failed');
+			tap.match(err.message, /from.*service/);
+			tap.match(err.dbusName, 'org.freedesktop.DBus.Error.Failed');
+			tap.type(err, DBus.Error);
 
 			iface.ThrowsCustomError({ timeout: 1000 }, function(err, result) {
 				tap.notSame(err, null);
 				tap.same(result, null);
-				// tap.match(err.message, /from service/);
-				tap.match(err.message, 'test.dbus.TestService.Error');
+				tap.match(err.message, /from.*service/);
+				tap.match(err.dbusName, 'test.dbus.TestService.Error');
+				tap.type(err, DBus.Error);
 				done();
 				bus.disconnect();
 			});

--- a/test/client-property-error.test.js
+++ b/test/client-property-error.test.js
@@ -1,0 +1,22 @@
+var withService = require('./with-service');
+var tap = require('tap');
+var DBus = require('../');
+
+tap.plan(3);
+withService('service.js', function(err, done) {
+	if (err) throw err;
+
+	var dbus = new DBus();
+	var bus = dbus.getBus('session');
+
+	bus.getInterface('test.dbus.TestService', '/test/dbus/TestService', 'test.dbus.TestService.Interface1', function(err, iface) {
+		iface.getProperty('ErrorProperty', function(err, value) {
+			tap.notSame(err, null);
+			tap.same(value, null);
+			//tap.match(err.message, /from service/);
+			tap.match(err.message, 'org.freedesktop.DBus.Error.Failed');
+			done();
+			bus.disconnect();
+		});
+	});
+});

--- a/test/client-property-error.test.js
+++ b/test/client-property-error.test.js
@@ -2,7 +2,7 @@ var withService = require('./with-service');
 var tap = require('tap');
 var DBus = require('../');
 
-tap.plan(3);
+tap.plan(4);
 withService('service.js', function(err, done) {
 	if (err) throw err;
 
@@ -13,8 +13,8 @@ withService('service.js', function(err, done) {
 		iface.getProperty('ErrorProperty', function(err, value) {
 			tap.notSame(err, null);
 			tap.same(value, null);
-			//tap.match(err.message, /from service/);
-			tap.match(err.message, 'org.freedesktop.DBus.Error.Failed');
+			tap.match(err.message, /from.*service/);
+			tap.type(err, DBus.Error);
 			done();
 			bus.disconnect();
 		});

--- a/test/client-property.test.js
+++ b/test/client-property.test.js
@@ -21,7 +21,6 @@ withService('service.js', function(err, done) {
 						tap.equal(value, 'http://stem.mandice.org');
 
 						iface.getProperties(function(err, props) {
-							console.log(props);
 							tap.equal(props.Author, 'Douglas Adams');
 							tap.equal(props.URL, 'http://stem.mandice.org');
 							done();

--- a/test/client-property.test.js
+++ b/test/client-property.test.js
@@ -21,6 +21,7 @@ withService('service.js', function(err, done) {
 						tap.equal(value, 'http://stem.mandice.org');
 
 						iface.getProperties(function(err, props) {
+							console.log(props);
 							tap.equal(props.Author, 'Douglas Adams');
 							tap.equal(props.URL, 'http://stem.mandice.org');
 							done();

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -1,0 +1,11 @@
+var tap = require('tap');
+var DBus = require('../');
+
+tap.plan(5);
+
+var baseError = new DBus.Error('test.dbus.TestService.BaseError', 'Basic error');
+tap.type(baseError, Error);
+tap.type(baseError, DBus.Error);
+tap.equal(baseError.dbusName, 'test.dbus.TestService.BaseError');
+tap.equal(baseError.message, 'Basic error');
+tap.match(baseError.toString(), /DBusError/);

--- a/test/service-create-remove-object.test.js
+++ b/test/service-create-remove-object.test.js
@@ -56,7 +56,7 @@ function checkInterface(bus, value, callback) {
 				if (!err) {
 					return callback(null, true);
 				}
-				if (/UnknownMethod/.test(err.message)) {
+				if (err instanceof DBus.Error && /UnknownMethod/.test(err.dbusName)) {
 					// This object doesn't exist. We're good.
 					return callback(null, false);
 				}

--- a/test/service.js
+++ b/test/service.js
@@ -24,6 +24,20 @@ iface1.addMethod('LongProcess', { out: DBus.Define(Number) }, function(callback)
 	}, 5000).unref();
 });
 
+iface1.addMethod('ThrowsError', { out: DBus.Define(Number) }, function(callback) {
+	setTimeout(function() {
+		callback(new Error('This is an error thrown from the service'));
+	}, 100);
+});
+
+iface1.addMethod('ThrowsCustomError', { out: DBus.Define(Number) }, function(callback) {
+	setTimeout(function() {
+		var error = new Error('This is an error thrown from the service');
+		error.dbusName = 'test.dbus.TestService.Error';
+		callback(error);
+	}, 100);
+});
+
 var author = 'Fred Chien';
 iface1.addProperty('Author', {
 	type: DBus.Define(String),
@@ -43,6 +57,14 @@ iface1.addProperty('URL', {
 	type: DBus.Define(String),
 	getter: function(callback) {
 		callback(url);
+	}
+});
+
+// Read-only property
+iface1.addProperty('ErrorProperty', {
+	type: DBus.Define(String),
+	getter: function(callback) {
+		callback(new Error('This is an error thrown from the service'));
 	}
 });
 

--- a/test/service.js
+++ b/test/service.js
@@ -32,8 +32,7 @@ iface1.addMethod('ThrowsError', { out: DBus.Define(Number) }, function(callback)
 
 iface1.addMethod('ThrowsCustomError', { out: DBus.Define(Number) }, function(callback) {
 	setTimeout(function() {
-		var error = new Error('This is an error thrown from the service');
-		error.dbusName = 'test.dbus.TestService.Error';
+		var error = new DBus.Error('test.dbus.TestService.Error', 'This is an error thrown from the service');
 		callback(error);
 	}, 100);
 });


### PR DESCRIPTION
From what I could tell, when a DBus service returned an error, this would be surfaced to this library as `new Error(errorName)`, with no way to get access to the error message. Similarly, when a service created by this library wanted to return an error instead of a value from a method call, it would have to return a `new Error(errorName)` with no way to set the error message.

These commits fix that by making it possible to retrieve (when receiving an error from a service) and specify (when implementing a service) both the error name and error message.

This is done via a new `DBus.Error` class which has a `dbusName` property that contains the name of the error. The regular `message` property of the error contains the human-readable message (which is a change from previous, where the regular `message` property contained the error name).