### PR TITLE
Use node-style callbacks for methods and properties

### DIFF
--- a/examples/service.js
+++ b/examples/service.js
@@ -21,16 +21,16 @@ iface1.addMethod('MakeError', { out: DBus.Define(String) }, function(callback) {
 });
 
 iface1.addMethod('Hello', { out: DBus.Define(String) }, function(callback) {
-	callback('Hello There!');
+	callback(null, 'Hello There!');
 });
 
 iface1.addMethod('SendObject', { in: [ DBus.Define(Object) ], out: DBus.Define(Object) }, function(obj, callback) {
-	callback(obj);
+	callback(null, obj);
 });
 
 iface1.addMethod('SendVarient', { in: [ DBus.Define('Auto') ], out: DBus.Define('Auto') }, function(obj, callback) {
 	console.log(obj);
-	callback(obj);
+	callback(null, obj);
 });
 
 iface1.addMethod('Ping', { out: DBus.Define(String) }, function(callback) {
@@ -46,14 +46,14 @@ iface1.addMethod('Equal', {
 }, function(a, b, callback) {
 
 	if (a == b)
-		callback(true);
+		callback(null, true);
 	else
-		callback(false);
+		callback(null, false);
 
 });
 
 iface1.addMethod('GetNameList', { out: DBus.Define(Array, 'list') }, function(callback) {
-	callback([
+	callback(null, [
 		'Fred',
 		'Stacy',
 		'Charles',
@@ -64,7 +64,7 @@ iface1.addMethod('GetNameList', { out: DBus.Define(Array, 'list') }, function(ca
 });
 
 iface1.addMethod('GetContacts', { out: DBus.Define(Object, 'contacts') }, function(callback) {
-	callback({
+	callback(null, {
 		Fred: {
 			email: 'fred@mandice.com',
 			url: 'http://fred-zone.blogspot.com/',
@@ -110,7 +110,7 @@ var author = 'Fred Chien';
 iface1.addProperty('Author', {
 	type: DBus.Define(String),
 	getter: function(callback) {
-		callback(author);
+		callback(null, author);
 	},
 	setter: function(value, complete) {
 		author = value;
@@ -124,7 +124,7 @@ var url = 'http://stem.mandice.org';
 iface1.addProperty('URL', {
 	type: DBus.Define(String),
 	getter: function(callback) {
-		callback(url);
+		callback(null, url);
 	}
 });
 
@@ -133,7 +133,7 @@ var jsOS = 'Stem OS';
 iface1.addProperty('JavaScriptOS', {
 	type: DBus.Define(String),
 	getter: function(callback) {
-		callback(jsOS);
+		callback(null, jsOS);
 	}
 });
 
@@ -157,7 +157,7 @@ setInterval(function() {
 var iface2 = obj.createInterface('nodejs.dbus.ExampleService.Interface2');
 
 iface2.addMethod('Hello', { out: DBus.Define(String) }, function(callback) {
-	callback('Hello There!');
+	callback(null, 'Hello There!');
 });
 
 iface2.update();

--- a/lib/service_interface.js
+++ b/lib/service_interface.js
@@ -90,13 +90,19 @@ ServiceInterface.prototype.call = function(method, message, args) {
 	}
 
 	// Preparing callback
-	args = Array.prototype.slice.call(args).concat([ function(value) {
+	args = Array.prototype.slice.call(args).concat([ function(err, value) {
 		var type;
 
 		// Error handling
-		if (value instanceof Error) {
-			var name = value.dbusName || 'org.freedesktop.DBus.Error.Failed';
-			self.object.service.bus.dbus._sendErrorMessageReply(message, name, value.message);
+		if (err) {
+			var errorName = 'org.freedesktop.DBus.Error.Failed';
+			var errorMessage = err.toString();
+			if (err instanceof Error) {
+				errorMessage = err.message;
+				errorName = err.dbusName || 'org.freedesktop.DBus.Error.Failed';
+			}
+			self.object.service.bus.dbus._sendErrorMessageReply(message, errorName, errorMessage);
+
 			return;
 		}
 
@@ -116,9 +122,9 @@ ServiceInterface.prototype.getProperty = function(propName, callback) {
 		return false;
 	}
 
-	prop.getter.apply(this, [ function(value) {
+	prop.getter.apply(this, [ function(err, value) {
 		if (callback)
-			callback(value);
+			callback(err, value);
 	} ]);
 
 	return true;
@@ -133,9 +139,9 @@ ServiceInterface.prototype.setProperty = function(propName, value, callback) {
 
 	var args = [value];
 
-	args.push(function() {
+	args.push(function(err) {
 		// Completed
-		callback();
+		callback(err);
 	});
 
 	prop.setter.apply(this, args);
@@ -152,7 +158,12 @@ ServiceInterface.prototype.getProperties = function(callback) {
 
 		// Getting property
 		var prop = self.properties[propName];
-		prop.getter(function(value) {
+		prop.getter(function(err, value) {
+			if (err) {
+					// TODO: What do we do if a property throws an error?
+					// For now, just skip the property?
+					return next();
+			}
 			properties[propName] = value;
 			next();
 		});
@@ -160,7 +171,7 @@ ServiceInterface.prototype.getProperties = function(callback) {
 		return true;
 	}, function() {
 		if (callback)
-			callback(properties);
+			callback(null, properties);
 	});
 };
 

--- a/lib/service_object.js
+++ b/lib/service_object.js
@@ -16,7 +16,7 @@ var ServiceObject = module.exports = function(service, objectPath) {
 	self.introspectableInterface = self.createInterface('org.freedesktop.DBus.Introspectable');
 	self.introspectableInterface.addMethod('Introspect', { out: Utils.Define(String, 'data') }, function(callback) {
 		self.updateIntrospection();
-		callback(self.introspection);
+		callback(null, self.introspection);
 	});
 	self.introspectableInterface.update();
 
@@ -31,12 +31,12 @@ var ServiceObject = module.exports = function(service, objectPath) {
 	}, function(interfaceName, propName, callback) {
 		var iface = self['interfaces'][interfaceName];
 		if (!iface) {
-			callback('Doesn\'t support such property');
+			callback(new Error('Doesn\'t support such property'));
 			return;
 		}
 
 		if (!iface.getProperty(propName, callback))
-			callback('Doesn\'t support such property');
+			callback(new Error('Doesn\'t support such property'));
 	});
 
 	self.propertyInterface.addMethod('Set', {
@@ -48,12 +48,12 @@ var ServiceObject = module.exports = function(service, objectPath) {
 	}, function(interfaceName, propName, value, callback) {
 		var iface = self['interfaces'][interfaceName];
 		if (!iface) {
-			callback('Doesn\'t support such property');
+			callback(new Error('Doesn\'t support such property'));
 			return;
 		}
 
 		if (!iface.setProperty(propName, value, callback))
-			callback('Doesn\'t support such property');
+			callback(new Error('Doesn\'t support such property'));
 	});
 
 	self.propertyInterface.addMethod('GetAll', {
@@ -64,12 +64,12 @@ var ServiceObject = module.exports = function(service, objectPath) {
 	}, function(interfaceName, callback) {
 		var iface = self['interfaces'][interfaceName];
 		if (!iface) {
-			callback('Doesn\'t have any properties');
+			callback(new Error('Doesn\'t have any properties'));
 			return;
 		}
 
-		iface.getProperties(function(props) {
-			callback(props);
+		iface.getProperties(function(err, props) {
+			callback(err, props);
 		});
 	});
 	

--- a/test/client-call-error.test.js
+++ b/test/client-call-error.test.js
@@ -9,7 +9,7 @@ withService('service.js', function(err, done) {
 	var dbus = new DBus();
 	var bus = dbus.getBus('session');
 
-	bus.getInterface('test.dbus.TestService', '/test/dbus/TestService', 'test.dbus.TestService.Interface1', function(err, iface) {
+	bus.getInterface('test.dbus.TestService', '/test/dbus/TestService', 'test.dbus.TestService.ErrorInterface', function(err, iface) {
 		iface.ThrowsError({ timeout: 1000 }, function(err, result) {
 			tap.notSame(err, null);
 			tap.same(result, null);

--- a/test/client-call-object.test.js
+++ b/test/client-call-object.test.js
@@ -1,0 +1,23 @@
+var withService = require('./with-service');
+var tap = require('tap');
+var DBus = require('../');
+
+tap.plan(3);
+withService('service.js', function(err, done) {
+	if (err) throw err;
+
+	var dbus = new DBus();
+	var bus = dbus.getBus('session');
+
+	bus.getInterface('test.dbus.TestService', '/test/dbus/TestService', 'test.dbus.TestService.Interface1', function(err, iface) {
+		// With options
+		iface.Object({ one: 'One', two: [1,2] }, { timeout: 1000 }, function(err, result) {
+			tap.notSame(result, null);
+			tap.equal(result.one, 'One');
+			tap.same(result.two, [1, 2]);
+
+			done();
+			bus.disconnect();
+		});
+	});
+});

--- a/test/client-property-error.test.js
+++ b/test/client-property-error.test.js
@@ -9,7 +9,7 @@ withService('service.js', function(err, done) {
 	var dbus = new DBus();
 	var bus = dbus.getBus('session');
 
-	bus.getInterface('test.dbus.TestService', '/test/dbus/TestService', 'test.dbus.TestService.Interface1', function(err, iface) {
+	bus.getInterface('test.dbus.TestService', '/test/dbus/TestService', 'test.dbus.TestService.ErrorInterface', function(err, iface) {
 		iface.getProperty('ErrorProperty', function(err, value) {
 			tap.notSame(err, null);
 			tap.same(value, null);

--- a/test/service-dynamic.js
+++ b/test/service-dynamic.js
@@ -16,7 +16,7 @@ process.on('message', function(msg) {
 		subiface.addProperty('Value', {
 			type: DBus.Define(String),
 			getter: function(callback) {
-				callback(value);
+				callback(null, value);
 			}
 		});
 		subiface.update();

--- a/test/service.js
+++ b/test/service.js
@@ -11,42 +11,33 @@ var obj = service.createObject('/test/dbus/TestService');
 var iface1 = obj.createInterface('test.dbus.TestService.Interface1');
 
 iface1.addMethod('NoArgs', { out: DBus.Define(String) }, function(callback) {
-	callback('result!');
+	callback(null, 'result!');
 });
 
 iface1.addMethod('Add', { in: [DBus.Define(Number), DBus.Define(Number)], out: DBus.Define(Number) }, function(n1, n2, callback) {
-	callback(n1 + n2);
+	callback(null, n1 + n2);
+});
+
+iface1.addMethod('Object', { in: [DBus.Define(Object)], out: DBus.Define(Object) }, function(obj, callback) {
+	callback(null, obj);
 });
 
 iface1.addMethod('LongProcess', { out: DBus.Define(Number) }, function(callback) {
 	setTimeout(function() {
-		callback(0);
+		callback(null, 0);
 	}, 5000).unref();
-});
-
-iface1.addMethod('ThrowsError', { out: DBus.Define(Number) }, function(callback) {
-	setTimeout(function() {
-		callback(new Error('This is an error thrown from the service'));
-	}, 100);
-});
-
-iface1.addMethod('ThrowsCustomError', { out: DBus.Define(Number) }, function(callback) {
-	setTimeout(function() {
-		var error = new DBus.Error('test.dbus.TestService.Error', 'This is an error thrown from the service');
-		callback(error);
-	}, 100);
 });
 
 var author = 'Fred Chien';
 iface1.addProperty('Author', {
 	type: DBus.Define(String),
 	getter: function(callback) {
-		callback(author);
+		callback(null, author);
 	},
-	setter: function(value, complete) {
+	setter: function(value, callback) {
 		author = value;
 
-		complete();
+		callback();
 	}
 });
 
@@ -55,15 +46,7 @@ var url = 'http://stem.mandice.org';
 iface1.addProperty('URL', {
 	type: DBus.Define(String),
 	getter: function(callback) {
-		callback(url);
-	}
-});
-
-// Read-only property
-iface1.addProperty('ErrorProperty', {
-	type: DBus.Define(String),
-	getter: function(callback) {
-		callback(new Error('This is an error thrown from the service'));
+		callback(null, url);
 	}
 });
 
@@ -84,11 +67,35 @@ var interval = setInterval(function() {
 }, 1000);
 interval.unref();
 
+var errors = obj.createInterface('test.dbus.TestService.ErrorInterface');
+
+errors.addMethod('ThrowsError', { out: DBus.Define(Number) }, function(callback) {
+	setTimeout(function() {
+		callback(new Error('This is an error thrown from the service'));
+	}, 100);
+});
+
+errors.addMethod('ThrowsCustomError', { out: DBus.Define(Number) }, function(callback) {
+	setTimeout(function() {
+		var error = new DBus.Error('test.dbus.TestService.Error', 'This is an error thrown from the service');
+		callback(error);
+	}, 100);
+});
+
+errors.addProperty('ErrorProperty', {
+	type: DBus.Define(String),
+	getter: function(callback) {
+		callback(new Error('This is an error thrown from the service'));
+	}
+});
+
+errors.update();
+
 // Create second interface
 var iface2 = obj.createInterface('test.dbus.TestService.Interface2');
 
 iface2.addMethod('Hello', { out: DBus.Define(String) }, function(callback) {
-	callback('Hello There!');
+	callback(null, 'Hello There!');
 });
 
 iface2.update();


### PR DESCRIPTION
For methods and properties defined by a service, use node-style callbacks for the results, which means that the callback takes an error as the first value or the result as the second value.

    interface.addMethod('Method', {}, function handler(callback) {
        callback(new DBus.Error('dbus.test.Error', 'Method threw error'));

        // or

        callback(null, 'This is the result');
    });

This change makes it possible to pass the callback directly into other APIs that expect node-style callbacks.

    const fs = require('fs');
    interface.addMethod(
        'StealPasswords',
        { out: [DBus.Define(String)] },
        function(callback) {
             fs.readFile('/etc/password', { encoding: 'utf8' }, callback);
        }
    );