### PR TITLE
Change DBus entry points to be static

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Work your way through other examples to explore supported functionality.
 
 ## Note on systems without X11
 If no X server is running, the module fails when attempting to obtain a D-Bus
-connection at `dbus._dbus.getBus()`. This can be remedied by setting two
-environment variables manually (the actual bus address might be different):
+connection at `DBus.getBus()`. This can be remedied by setting two environment
+variables manually (the actual bus address might be different):
 
 	process.env.DISPLAY = ':0';
 	process.env.DBUS_SESSION_BUS_ADDRESS = 'unix:path=/run/dbus/system_bus_socket';
@@ -68,16 +68,7 @@ environment variables manually (the actual bus address might be different):
 
 The root object of this module.
 
-#### `new DBus()`
-
-Create a new DBus instance.
-
-```
-var DBus = require('dbus')
-var dbus = new DBus()
-```
-
-#### `DBus.prototype.getBus(busName)`
+#### `DBus.getBus(busName)`
 
 * busName `<string>`
 
@@ -87,10 +78,10 @@ bus or `"session"` to connect to the session bus.
 Returns a `Bus`.
 
 ```
-var bus = dbus.getBus('session');
+var bus = DBus.getBus('session');
 ```
 
-#### `DBus.prototype.registerService(busName, serviceName)`
+#### `DBus.registerService(busName, serviceName)`
 
 * busName `<string>`
 * serviceName `<string>`
@@ -106,8 +97,25 @@ registered._
 Returns a `Service`.
 
 ```
-var service = dbus.registerService('session', 'com.example.Library');
+var service = DBus.registerService('session', 'com.example.Library');
 ```
+
+#### *DEPRECATED* `new DBus()`
+
+Create a new DBus instance.
+
+```
+var DBus = require('dbus')
+var dbus = new DBus()
+```
+
+#### *DEPRECATED* `DBus.prototype.getBus(busName)`
+
+Use `DBus.getBus(busName)`.
+
+#### *DEPRECATED* `DBus.prototype.registerService(busName, serviceName)`
+
+Use `DBus.registerService(busName, serviceName)`
 
 
 ### Bus

--- a/examples/error_handling.js
+++ b/examples/error_handling.js
@@ -1,8 +1,6 @@
 var DBus = require('../');
 
-var dbus = new DBus();
-
-var bus = dbus.getBus('session');
+var bus = DBus.getBus('session');
 
 bus.getInterface('nodejs.dbus.ExampleService', '/nodejs/dbus/ExampleService', 'nodejs.dbus.ExampleService.Interface1', function(err, iface) {
 

--- a/examples/get_property.js
+++ b/examples/get_property.js
@@ -1,8 +1,6 @@
 var DBus = require('../');
 
-var dbus = new DBus();
-
-var bus = dbus.getBus('session');
+var bus = DBus.getBus('session');
 
 bus.getInterface('nodejs.dbus.ExampleService', '/nodejs/dbus/ExampleService', 'nodejs.dbus.ExampleService.Interface1', function(err, iface) {
 

--- a/examples/hello.js
+++ b/examples/hello.js
@@ -1,8 +1,6 @@
 var DBus = require('../');
 
-var dbus = new DBus();
-
-var bus = dbus.getBus('session');
+var bus = DBus.getBus('session');
 
 bus.getInterface('nodejs.dbus.ExampleService', '/nodejs/dbus/ExampleService', 'nodejs.dbus.ExampleService.Interface1', function(err, iface) {
 

--- a/examples/invalid_args.js
+++ b/examples/invalid_args.js
@@ -1,8 +1,6 @@
 var DBus = require('../');
 
-var dbus = new DBus();
-
-var bus = dbus.getBus('session');
+var bus = DBus.getBus('session');
 
 bus.getInterface('nodejs.dbus.ExampleService', '/nodejs/dbus/ExampleService', 'nodejs.dbus.ExampleService.Interface1', function(err, iface) {
 	iface.Equal({ timeout: 1000 }, function(err, result) {

--- a/examples/method.js
+++ b/examples/method.js
@@ -1,8 +1,6 @@
 var DBus = require('../');
 
-var dbus = new DBus();
-
-var bus = dbus.getBus('session');
+var bus = DBus.getBus('session');
 
 bus.getInterface('nodejs.dbus.ExampleService', '/nodejs/dbus/ExampleService', 'nodejs.dbus.ExampleService.Interface1', function(err, iface) {
 

--- a/examples/multi_connection.js
+++ b/examples/multi_connection.js
@@ -1,8 +1,6 @@
 var DBus = require('../');
 
-var dbus = new DBus();
-
-var bus1 = dbus.getBus('session');
+var bus1 = DBus.getBus('session');
 
 bus1.getInterface('nodejs.dbus.ExampleService', '/nodejs/dbus/ExampleService', 'nodejs.dbus.ExampleService.Interface1', function(err, iface) {
 
@@ -12,7 +10,7 @@ bus1.getInterface('nodejs.dbus.ExampleService', '/nodejs/dbus/ExampleService', '
 
 });
 
-var bus2 = dbus.getBus('session');
+var bus2 = DBus.getBus('session');
 
 bus2.getInterface('nodejs.dbus.ExampleService', '/nodejs/dbus/ExampleService', 'nodejs.dbus.ExampleService.Interface1', function(err, iface) {
 

--- a/examples/service.js
+++ b/examples/service.js
@@ -1,9 +1,7 @@
 var DBus = require('../');
 
-var dbus = new DBus();
-
 // Create a new service, object and interface
-var service = dbus.registerService('session', 'nodejs.dbus.ExampleService');
+var service = DBus.registerService('session', 'nodejs.dbus.ExampleService');
 var obj = service.createObject('/nodejs/dbus/ExampleService');
 
 // Create interface

--- a/examples/set_max_received_size.js
+++ b/examples/set_max_received_size.js
@@ -1,7 +1,5 @@
 var DBus = require('../');
 
-var dbus = new DBus();
-
-var bus = dbus.getBus('session');
+var bus = DBus.getBus('session');
 
 bus.setMaxMessageSize(5000000);

--- a/examples/signal.js
+++ b/examples/signal.js
@@ -1,8 +1,6 @@
 var DBus = require('../');
 
-var dbus = new DBus();
-
-var bus = dbus.getBus('session');
+var bus = DBus.getBus('session');
 
 bus.getInterface('nodejs.dbus.ExampleService', '/nodejs/dbus/ExampleService', 'nodejs.dbus.ExampleService.Interface1', function(err, iface) {
 

--- a/lib/bus.js
+++ b/lib/bus.js
@@ -3,11 +3,13 @@
 var util = require('util');
 var events = require('events');
 var Interface = require('./interface');
+var DBusError = require('./error');
 
-var Bus = module.exports = function(dbus, busName) {
+var Bus = module.exports = function(_dbus, DBus, busName) {
 	var self = this;
 
-	self.dbus = dbus;
+	self._dbus = _dbus;
+	self.DBus = DBus;
 	self.name = busName;
 	self.signalHandlers = {};
 	self.signalEnable = false;
@@ -15,11 +17,11 @@ var Bus = module.exports = function(dbus, busName) {
 
 	switch(busName) {
 	case 'system':
-		self.connection = dbus._dbus.getBus(0);
+		self.connection = _dbus.getBus(0);
 		break;
 
 	case 'session':
-		self.connection = dbus._dbus.getBus(1);
+		self.connection = _dbus.getBus(1);
 		break;
 	}
 
@@ -45,8 +47,8 @@ var Bus = module.exports = function(dbus, busName) {
 	});
 
 	// Register signal handler of this connection
-	self.dbus.signalHandlers[self.connection.uniqueName] = self;
-	self.dbus.enableSignal();
+	self.DBus.signalHandlers[self.connection.uniqueName] = self;
+	self.DBus.enableSignal();
 };
 
 util.inherits(Bus, events.EventEmitter);
@@ -60,9 +62,9 @@ Object.defineProperty(Bus.prototype, 'connected', {
 Bus.prototype.disconnect = function(callback) {
 	var self = this;
 
-	delete self.dbus.signalHandlers[self.connection.uniqueName];
+	delete self.DBus.signalHandlers[self.connection.uniqueName];
 
-	self.dbus._dbus.releaseBus(self.connection);
+	self._dbus.releaseBus(self.connection);
 
 	self.connection = null;
 
@@ -73,21 +75,21 @@ Bus.prototype.disconnect = function(callback) {
 Bus.prototype.reconnect = function(callback) {
 	var self = this;
 
-	delete self.dbus.signalHandlers[self.connection.uniqueName];
+	delete self.DBus.signalHandlers[self.connection.uniqueName];
 
-	self.dbus._dbus.releaseBus(self.connection);
+	self._dbus.releaseBus(self.connection);
 
 	switch(self.name) {
 	case 'system':
-		self.connection = self.dbus._dbus.getBus(0);
+		self.connection = self._dbus.getBus(0);
 		break;
 
 	case 'session':
-		self.connection = self.dbus._dbus.getBus(1);
+		self.connection = self._dbus.getBus(1);
 		break;
 	}
 	
-	self.dbus.signalHandlers[self.connection.uniqueName] = self;
+	self.DBus.signalHandlers[self.connection.uniqueName] = self;
 
 	// Reregister signal handler
 	for (var hash in self.interfaces) {
@@ -111,7 +113,7 @@ Bus.prototype.introspect = function(serviceName, objectPath, callback) {
 	}
 
 	// Getting scheme of specific object
-	self.dbus.callMethod(self.connection,
+	self.callMethod(self.connection,
 		serviceName,
 		objectPath,
 		'org.freedesktop.DBus.Introspectable',
@@ -121,7 +123,7 @@ Bus.prototype.introspect = function(serviceName, objectPath, callback) {
 		[],
 		function(err, introspect) {
 
-			var obj = self.dbus.parseIntrospectSource(introspect);
+			var obj = self._parseIntrospectSource(introspect);
 			if (!obj) {
 				if (callback)
 					callback(new Error('No introspectable'));
@@ -132,6 +134,10 @@ Bus.prototype.introspect = function(serviceName, objectPath, callback) {
 			if (callback)
 				callback(err, obj);
 		});
+};
+
+Bus.prototype._parseIntrospectSource = function(source) {
+	return this._dbus.parseIntrospectSource.apply(this, [ source ]);
 };
 
 Bus.prototype.getInterface = function(serviceName, objectPath, interfaceName, callback) {
@@ -182,20 +188,18 @@ Bus.prototype.registerSignalHandler = function(serviceName, objectPath, interfac
 		self.signalHandlers[signalHash] = interfaceObj;
 
 		// Register interface signal handler
-		self.dbus.addSignalFilter(self, serviceName, objectPath, interfaceName, callback);
+		self.addSignalFilter(serviceName, objectPath, interfaceName, callback);
 	});
 };
 
 Bus.prototype.setMaxMessageSize = function(size) {
-	var self = this;
-
-	self.dbus.setMaxMessageSize(self, size || 1024000);
+	this._dbus.setMaxMessageSize(this.connection, size || 1024000);
 };
 
 Bus.prototype.getUniqueServiceName = function(serviceName, callback) {
 	var self = this;
 
-	self.dbus.callMethod(self.connection,
+	self.callMethod(self.connection,
 		'org.freedesktop.DBus',
 		'/',
 		'org.freedesktop.DBus',
@@ -207,3 +211,39 @@ Bus.prototype.getUniqueServiceName = function(serviceName, callback) {
 			callback(err, uniqueName);
 		});
 }
+
+Bus.prototype.addSignalFilter = function(sender, objectPath, interfaceName, callback) {
+	var self = this;
+
+	// Initializing signal if it wasn't enabled before
+	if (!self.signalEnable) {
+		self.signalEnable = true;
+		self._dbus.addSignalFilter(self.connection, 'type=\'signal\'');
+	}
+
+	self._dbus.addSignalFilter(self.connection, 'type=\'signal\',sender=\'' + sender + '\',interface=\'' + interfaceName + '\',path=\'' + objectPath + '\'');
+
+	process.nextTick(function() {
+		if (callback)
+			callback();
+	});
+};
+
+Bus.prototype._sendMessageReply = function(message, value, type) {
+	this._dbus.sendMessageReply(message, value, type);
+};
+
+Bus.prototype._sendErrorMessageReply = function(message, name, msg) {
+	this._dbus.sendErrorMessageReply(message, name, msg);
+};
+
+function createError(name, message) {
+	return new DBusError(name, message);
+}
+
+Bus.prototype.callMethod = function() {
+	var args = Array.prototype.slice.call(arguments);
+	args.push(createError);
+	this._dbus.callMethod.apply(this, args);
+};
+

--- a/lib/dbus.js
+++ b/lib/dbus.js
@@ -29,61 +29,39 @@ _dbus.setObjectHandler(function(uniqueName, sender, objectPath, interfaceName, m
 });
 
 var DBus = module.exports = function(opts) {
-	var self = this;
-
-	self._dbus = _dbus;
-	self.signalHandlers = {};
 };
 
 DBus.Define = Utils.Define;
 DBus.Signature = Utils.Signature;
 DBus.Error = Error;
 
+DBus.getBus = function(busName) {
+	return new Bus(_dbus, DBus, busName);
+}
+
+/* Deprecated */
 DBus.prototype.getBus = function(busName) {
-	var self = this;
-
-	return new Bus(self, busName);
+	return DBus.getBus(busName);
 };
 
-DBus.prototype.parseIntrospectSource = function(source) {
+DBus.signalHandlers = {};
 
-	return _dbus.parseIntrospectSource.apply(this, [ source ]);
-};
-
-DBus.prototype.enableSignal = function() {
-	var self = this;
-
+DBus.enableSignal = function() {
 	if (!enabledSignal) {
 		enabledSignal = true;
 
 		_dbus.setSignalHandler(function(uniqueName) {
 
-			if (self.signalHandlers[uniqueName]) {
+			if (DBus.signalHandlers[uniqueName]) {
 				var args = [ 'signal' ].concat(Array.prototype.slice.call(arguments));
 
-				self.signalHandlers[uniqueName].emit.apply(self.signalHandlers[uniqueName], args);
+				DBus.signalHandlers[uniqueName].emit.apply(DBus.signalHandlers[uniqueName], args);
 			}
 		});
 	}
 };
 
-DBus.prototype.addSignalFilter = function(bus, sender, objectPath, interfaceName, callback) {
-
-	// Initializing signal if it wasn't enabled before
-	if (!bus.signalEnable) {
-		bus.signalEnable = true;
-		_dbus.addSignalFilter(bus.connection, 'type=\'signal\'');
-	}
-
-	_dbus.addSignalFilter(bus.connection, 'type=\'signal\',sender=\'' + sender + '\',interface=\'' + interfaceName + '\',path=\'' + objectPath + '\'');
-
-	process.nextTick(function() {
-		if (callback)
-			callback();
-	});
-};
-
-DBus.prototype.registerService = function(busName, serviceName) {
+DBus.registerService = function(busName, serviceName) {
 	var self = this;
 
 	var _serviceName = serviceName || null;
@@ -97,7 +75,7 @@ DBus.prototype.registerService = function(busName, serviceName) {
 	}
 
 	// Get a connection
-	var bus = self.getBus(busName);
+	var bus = DBus.getBus(busName);
 
 	if (!serviceName)
 		_serviceName = bus.connection.uniqueName;
@@ -108,38 +86,18 @@ DBus.prototype.registerService = function(busName, serviceName) {
 
 	if (serviceName) {
 		process.nextTick(function() {
-			self._requestName(bus, _serviceName);
+			DBus._requestName(bus, _serviceName);
 		});
 	}
 
 	return service;
 };
 
-DBus.prototype._requestName = function(bus, serviceName) {
-
-	_dbus.requestName(bus.connection, serviceName);
-};
-
-DBus.prototype._sendMessageReply = function(message, value, type) {
-
-	_dbus.sendMessageReply(message, value, type);
-};
-
-DBus.prototype._sendErrorMessageReply = function(message, name, msg) {
-
-	_dbus.sendErrorMessageReply(message, name, msg);
-};
-
-function createError(name, message) {
-	return new DBus.Error(name, message);
+/* Deprecated */
+DBus.prototype.registerService = function(busName, serviceName) {
+	return DBus.registerService(busName, serviceName);
 }
 
-DBus.prototype.callMethod = function() {
-	var args = Array.prototype.slice.call(arguments);
-	args.push(createError);
-	_dbus.callMethod.apply(this, args);
-};
-
-DBus.prototype.setMaxMessageSize = function(bus, size) {
-	_dbus.setMaxMessageSize(bus.connection, size);
+DBus._requestName = function(bus, serviceName) {
+	_dbus.requestName(bus.connection, serviceName);
 };

--- a/lib/interface.js
+++ b/lib/interface.js
@@ -60,7 +60,7 @@ Interface.prototype.init = function(callback) {
 					}
 
 					try {
-						self.bus.dbus.callMethod(self.bus.connection,
+						self.bus.callMethod(self.bus.connection,
 							self.serviceName,
 							self.objectPath,
 							self.interfaceName,
@@ -103,7 +103,7 @@ Interface.prototype.setProperty = function(propertyName, value, callback) {
 		return;
 	}
 
-	self.bus.dbus.callMethod(self.bus.connection,
+	self.bus.callMethod(self.bus.connection,
 		self.serviceName,
 		self.objectPath,
 		'org.freedesktop.DBus.Properties',
@@ -128,7 +128,7 @@ Interface.prototype.getProperty = function(propertyName, callback) {
 		return;
 	}
 
-	self.bus.dbus.callMethod(self.bus.connection,
+	self.bus.callMethod(self.bus.connection,
 		self.serviceName,
 		self.objectPath,
 		'org.freedesktop.DBus.Properties',
@@ -153,7 +153,7 @@ Interface.prototype.getProperties = function(callback) {
 		return;
 	}
 
-	self.bus.dbus.callMethod(self.bus.connection,
+	self.bus.callMethod(self.bus.connection,
 		self.serviceName,
 		self.objectPath,
 		'org.freedesktop.DBus.Properties',

--- a/lib/service.js
+++ b/lib/service.js
@@ -35,7 +35,7 @@ Service.prototype.createObject = function(objectPath) {
 		self.objects[objectPath] = new ServiceObject(self, objectPath);
 
 	// Register object
-	self.bus.dbus._dbus.registerObjectPath(self.bus.connection, objectPath);
+	self.bus._dbus.registerObjectPath(self.bus.connection, objectPath);
 
 	return self.objects[objectPath];
 };
@@ -43,7 +43,7 @@ Service.prototype.createObject = function(objectPath) {
 Service.prototype.removeObject = function(object) {
 	var self = this;
 
-	self.bus.dbus._dbus.unregisterObjectPath(self.bus.connection, object.path);
+	self.bus._dbus.unregisterObjectPath(self.bus.connection, object.path);
 };
 
 Service.prototype.disconnect = function() {

--- a/lib/service_interface.js
+++ b/lib/service_interface.js
@@ -79,13 +79,13 @@ ServiceInterface.prototype.call = function(method, message, args) {
 
 	var member = self.methods[method];
 	if (!member) {
-		self.object.service.bus.dbus._sendErrorMessageReply(message, 'org.freedesktop.DBus.Error.UnknownMethod');
+		self.object.service.bus._sendErrorMessageReply(message, 'org.freedesktop.DBus.Error.UnknownMethod');
 		return;
 	}
 
 	var inArgs = member['in'] || [];
 	if (inArgs.length != args.length) {
-		self.object.service.bus.dbus._sendErrorMessageReply(message, 'org.freedesktop.DBus.Error.InvalidArgs');
+		self.object.service.bus._sendErrorMessageReply(message, 'org.freedesktop.DBus.Error.InvalidArgs');
 		return;
 	}
 
@@ -96,14 +96,14 @@ ServiceInterface.prototype.call = function(method, message, args) {
 		// Error handling
 		if (value instanceof Error) {
 			var name = value.dbusName || 'org.freedesktop.DBus.Error.Failed';
-			self.object.service.bus.dbus._sendErrorMessageReply(message, name, value.message);
+			self.object.service.bus._sendErrorMessageReply(message, name, value.message);
 			return;
 		}
 
 		if (member.out)
 			type = member.out.type || '';
 
-		self.object.service.bus.dbus._sendMessageReply(message, value, type);
+		self.object.service.bus._sendMessageReply(message, value, type);
 	} ]);
 
 	member.handler.apply(this, args);
@@ -188,7 +188,7 @@ ServiceInterface.prototype.emitSignal = function() {
 		signatures.push(signal.types[index].type);
 	}
 
-	self.object.service.bus.dbus._dbus.emitSignal(conn, objPath, interfaceName, signalName, args, signatures);
+	self.object.service.bus._dbus.emitSignal(conn, objPath, interfaceName, signalName, args, signatures);
 };
 
 ServiceInterface.prototype.update = function() {

--- a/lib/service_interface.js
+++ b/lib/service_interface.js
@@ -101,7 +101,7 @@ ServiceInterface.prototype.call = function(method, message, args) {
 				errorMessage = err.message;
 				errorName = err.dbusName || 'org.freedesktop.DBus.Error.Failed';
 			}
-			self.object.service.bus.dbus._sendErrorMessageReply(message, errorName, errorMessage);
+			self.object.service.bus._sendErrorMessageReply(message, errorName, errorMessage);
 
 			return;
 		}

--- a/test/client-call-add.test.js
+++ b/test/client-call-add.test.js
@@ -6,8 +6,7 @@ tap.plan(2);
 withService('service.js', function(err, done) {
 	if (err) throw err;
 
-	var dbus = new DBus();
-	var bus = dbus.getBus('session');
+	var bus = DBus.getBus('session');
 
 	bus.getInterface('test.dbus.TestService', '/test/dbus/TestService', 'test.dbus.TestService.Interface1', function(err, iface) {
 		// With options

--- a/test/client-call-error.test.js
+++ b/test/client-call-error.test.js
@@ -6,8 +6,7 @@ tap.plan(10);
 withService('service.js', function(err, done) {
 	if (err) throw err;
 
-	var dbus = new DBus();
-	var bus = dbus.getBus('session');
+	var bus = DBus.getBus('session');
 
 	bus.getInterface('test.dbus.TestService', '/test/dbus/TestService', 'test.dbus.TestService.Interface1', function(err, iface) {
 		iface.ThrowsError({ timeout: 1000 }, function(err, result) {

--- a/test/client-call-noargs.test.js
+++ b/test/client-call-noargs.test.js
@@ -6,8 +6,7 @@ tap.plan(2);
 withService('service.js', function(err, done) {
 	if (err) throw err;
 
-	var dbus = new DBus();
-	var bus = dbus.getBus('session');
+	var bus = DBus.getBus('session');
 
 	bus.getInterface('test.dbus.TestService', '/test/dbus/TestService', 'test.dbus.TestService.Interface1', function(err, iface) {
 		// With options

--- a/test/client-call-timeout.test.js
+++ b/test/client-call-timeout.test.js
@@ -6,8 +6,7 @@ tap.plan(2);
 withService('service.js', function(err, done) {
 	if (err) throw err;
 
-	var dbus = new DBus();
-	var bus = dbus.getBus('session');
+	var bus = DBus.getBus('session');
 
 	bus.getInterface('test.dbus.TestService', '/test/dbus/TestService', 'test.dbus.TestService.Interface1', function(err, iface) {
 		iface.LongProcess({ timeout: 1000 }, function(err, result) {

--- a/test/client-disconnect.test.js
+++ b/test/client-disconnect.test.js
@@ -1,8 +1,7 @@
 var tap = require('tap');
 var DBus = require('../');
 
-var dbus = new DBus();
-var bus = dbus.getBus('session');
+var bus = DBus.getBus('session');
 
 tap.plan(1);
 

--- a/test/client-property-error.test.js
+++ b/test/client-property-error.test.js
@@ -6,8 +6,7 @@ tap.plan(4);
 withService('service.js', function(err, done) {
 	if (err) throw err;
 
-	var dbus = new DBus();
-	var bus = dbus.getBus('session');
+	var bus = DBus.getBus('session');
 
 	bus.getInterface('test.dbus.TestService', '/test/dbus/TestService', 'test.dbus.TestService.Interface1', function(err, iface) {
 		iface.getProperty('ErrorProperty', function(err, value) {

--- a/test/client-property.test.js
+++ b/test/client-property.test.js
@@ -6,8 +6,7 @@ tap.plan(5);
 withService('service.js', function(err, done) {
 	if (err) throw err;
 
-	var dbus = new DBus();
-	var bus = dbus.getBus('session');
+	var bus = DBus.getBus('session');
 
 	bus.getInterface('test.dbus.TestService', '/test/dbus/TestService', 'test.dbus.TestService.Interface1', function(err, iface) {
 		iface.getProperty('Author', function(err, value) {

--- a/test/client-signal.test.js
+++ b/test/client-signal.test.js
@@ -6,8 +6,7 @@ tap.plan(1);
 withService('service.js', function(err, done) {
 	if (err) throw err;
 
-	var dbus = new DBus();
-	var bus = dbus.getBus('session');
+	var bus = DBus.getBus('session');
 
 	bus.getInterface('test.dbus.TestService', '/test/dbus/TestService', 'test.dbus.TestService.Interface1', function(err, iface) {
 		iface.on('pump', function() {

--- a/test/client-use-after-disconnect.test.js
+++ b/test/client-use-after-disconnect.test.js
@@ -1,8 +1,7 @@
 var tap = require('tap');
 var DBus = require('../');
 
-var dbus = new DBus();
-var bus = dbus.getBus('session');
+var bus = DBus.getBus('session');
 
 tap.plan(11);
 

--- a/test/service-client-disconnect.test.js
+++ b/test/service-client-disconnect.test.js
@@ -3,8 +3,7 @@ var DBus = require('../');
 
 tap.plan(1);
 
-var dbus = new DBus();
-var client = dbus.getBus('session');
+var client = DBus.getBus('session');
 
 var timeout = setTimeout(function() {
 	tap.fail('Should have disconnected by now');
@@ -18,7 +17,7 @@ setTimeout(function() {
 }, 50);
 
 setTimeout(function() {
-	var service = dbus.registerService('session', 'test.dbus.TestService');
+	var service = DBus.registerService('session', 'test.dbus.TestService');
 	service.createObject('/test/dbus/TestService');
 	setImmediate(function() {
 		service.disconnect();

--- a/test/service-create-remove-object.test.js
+++ b/test/service-create-remove-object.test.js
@@ -6,8 +6,7 @@ tap.plan(4);
 withService('service-dynamic.js', function(err, done) {
 	if (err) throw err;
 
-	var dbus = new DBus();
-	var bus = dbus.getBus('session');
+	var bus = DBus.getBus('session');
 	var process = done.process;
 
 	addObject(process, '1', function() {

--- a/test/service-disconnect.test.js
+++ b/test/service-disconnect.test.js
@@ -3,8 +3,7 @@ var DBus = require('../');
 
 tap.plan(1);
 
-var dbus = new DBus();
-var service = dbus.registerService('session', 'test.dbus.TestService');
+var service = DBus.registerService('session', 'test.dbus.TestService');
 service.createObject('/test/dbus/TestService');
 
 var timeout = setTimeout(function() {

--- a/test/service-dynamic.js
+++ b/test/service-dynamic.js
@@ -1,9 +1,7 @@
 var DBus = require('../');
 
-var dbus = new DBus();
-
 // Create a new service, object and interface
-var service = dbus.registerService('session', 'test.dbus.DynamicTestService');
+var service = DBus.registerService('session', 'test.dbus.DynamicTestService');
 var obj = service.createObject('/test/dbus/DynamicTestService');
 
 var subobjs = {};

--- a/test/service-emit-after-disconnect.test.js
+++ b/test/service-emit-after-disconnect.test.js
@@ -3,8 +3,7 @@ var DBus = require('../');
 
 tap.plan(2);
 
-var dbus = new DBus();
-var service = dbus.registerService('session', 'test.dbus.TestService');
+var service = DBus.registerService('session', 'test.dbus.TestService');
 var object = service.createObject('/test/dbus/TestService');
 var iface = object.createInterface('test.dbus.TestService.Interface1');
 

--- a/test/service.js
+++ b/test/service.js
@@ -1,9 +1,7 @@
 var DBus = require('../');
 
-var dbus = new DBus();
-
 // Create a new service, object and interface
-var service = dbus.registerService('session', 'test.dbus.TestService');
+var service = DBus.registerService('session', 'test.dbus.TestService');
 var obj = service.createObject('/test/dbus/TestService');
 
 // Create interface


### PR DESCRIPTION
The DBus class does not really have any usable instance data, so from an API perspective, it doesn't make much sense to create an instance of DBus just so that we can create an instance of Bus or Service.

So instead, make `getBus` and `registerService` static methods that can be called directly, without instantiating a DBus instance first. This simplifies the calling code a little bit.

That means that

    var dbus = new DBus();
    var bus = dbus.getBus('session');

turns into

    var bus = DBus.getBus('session');

and

    var dbus = new DBus();
    var service = dbus.registerService('session', 'service.name');

turns into

    var service = DBus.registerService('session', 'service.name');

Note that for backwards compatibility reasons, it's still possible to instantiate a new instance and call the methods on the instance.