### PR TITLE
Adding support for encoding dictionaries with non-string keys

### DIFF
--- a/test/client-call-intdict.test.js
+++ b/test/client-call-intdict.test.js
@@ -1,0 +1,22 @@
+var withService = require('./with-service');
+var tap = require('tap');
+var DBus = require('../');
+
+tap.plan(2);
+withService('service.js', function(err, done) {
+	if (err) throw err;
+
+	var dbus = new DBus();
+	var bus = dbus.getBus('session');
+
+	bus.getInterface('test.dbus.TestService', '/test/dbus/TestService', 'test.dbus.TestService.Interface1', function(err, iface) {
+		// With options
+		iface.IntDict({ 1: 'One', 42: 'Answer' }, { timeout: 1000 }, function(err, result) {
+			tap.notSame(result, null);
+			tap.same(result, [1, 42]);
+
+			done();
+			bus.disconnect();
+		});
+	});
+});

--- a/test/service.js
+++ b/test/service.js
@@ -20,6 +20,10 @@ iface1.addMethod('Object', { in: [DBus.Define(Object)], out: DBus.Define(Object)
 	callback(null, obj);
 });
 
+iface1.addMethod('IntDict', { in: [{ type: 'a{ys}' }], out: { type: 'ay' }}, function (dict, callback) {
+	callback(null, Object.keys(dict).sort());
+})
+
 iface1.addMethod('LongProcess', { out: DBus.Define(Number) }, function(callback) {
 	setTimeout(function() {
 		callback(null, 0);


### PR DESCRIPTION
DBus allows dictionary encodings using any primitive type as key.  This adds support for dictionaries with non-string keys.