### PR TITLE
Set property strict encoding

### DIFF
--- a/lib/interface.js
+++ b/lib/interface.js
@@ -103,12 +103,14 @@ Interface.prototype.setProperty = function(propertyName, value, callback) {
 		return;
 	}
 
+	var propSig = self.object['property'][propertyName].type;
+
 	self.bus.callMethod(self.bus.connection,
 		self.serviceName,
 		self.objectPath,
 		'org.freedesktop.DBus.Properties',
 		'Set',
-		'ssv',
+		{ type: 'ssv', concrete_type: 'ss' + propSig },
 		-1,
 		[ self.interfaceName, propertyName, value ],
 		function(err) {

--- a/src/dbus.cc
+++ b/src/dbus.cc
@@ -214,9 +214,11 @@ namespace NodeDBus {
 				dbus_signature_iter_init(&siter, sig);
 				for (unsigned int i = 0; i < argument_arr->Length(); ++i) {
 					char *arg_sig = dbus_signature_iter_get_signature(&siter);
+					DBusSignatureIter subSiter;
 					Local<Value> arg = argument_arr->Get(i);
 
-					if (!Encoder::EncodeObject(arg, &iter, arg_sig)) {
+					dbus_signature_iter_init(&subSiter, arg_sig);
+					if (!Encoder::EncodeObject(arg, &iter, &subSiter)) {
 						dbus_free(arg_sig);
 						break;
 					}

--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -151,12 +151,20 @@ typedef bool (*CheckTypeCallback) (Local<Value>& value, const char* sig);
 		return "";
 	}
 
-	bool EncodeObject(Local<Value> value, DBusMessageIter *iter, DBusSignatureIter *siter)
+	bool EncodeObject(Local<Value> value, DBusMessageIter *iter,
+		const DBusSignatureIter *siter,
+		const DBusSignatureIter *concreteSiter)
 	{
 		// printf("EncodeObject %s\n",signature);
 		// printf("%p", value);
 		Nan::HandleScope scope;
 		int type;
+		
+		if (concreteSiter == NULL)
+		{
+			// this is safe because we never modify siter
+			concreteSiter = siter;
+		}
 
 		// Get type of current value
 		type = dbus_signature_iter_get_current_type(siter);
@@ -313,11 +321,12 @@ typedef bool (*CheckTypeCallback) (Local<Value>& value, const char* sig);
 			}
 
 			DBusMessageIter subIter;
-			DBusSignatureIter arraySiter;
+			DBusSignatureIter arraySiter, arrayConcreteSiter;
 			char *array_sig = NULL;
 
 			// Getting signature of array object
 			dbus_signature_iter_recurse(siter, &arraySiter);
+			dbus_signature_iter_recurse(concreteSiter, &arrayConcreteSiter);
 			array_sig = dbus_signature_iter_get_signature(&arraySiter);
 
 			// Open array container to process elements in there
@@ -338,11 +347,12 @@ typedef bool (*CheckTypeCallback) (Local<Value>& value, const char* sig);
 
 				bool failed = false;
 				for (unsigned int i = 0; i < len; ++i) {
-					DBusSignatureIter dictSubSiter;
+					DBusSignatureIter dictSubSiter, dictSubConcreteSiter;
 					DBusMessageIter dict_iter;
 					
 					// Getting sub-signature object
 					dbus_signature_iter_recurse(&arraySiter, &dictSubSiter);
+					dbus_signature_iter_recurse(&arrayConcreteSiter, &dictSubConcreteSiter);
 
 					// Open dict entry container
 					if (!dbus_message_iter_open_container(&subIter, DBUS_TYPE_DICT_ENTRY, NULL, &dict_iter)) {
@@ -356,7 +366,7 @@ typedef bool (*CheckTypeCallback) (Local<Value>& value, const char* sig);
 					Local<Value> prop_value = value_object->Get(prop_key);
 
 					// Append the key
-					if (!EncodeObject(prop_key, &dict_iter, &dictSubSiter)) {
+					if (!EncodeObject(prop_key, &dict_iter, &dictSubSiter, &dictSubConcreteSiter)) {
 						dbus_message_iter_close_container(&subIter, &dict_iter); 
 						printf("Failed to encode element of dictionary\n");
 						failed = true;
@@ -365,7 +375,8 @@ typedef bool (*CheckTypeCallback) (Local<Value>& value, const char* sig);
 
 					// Append the value
 					dbus_signature_iter_next(&dictSubSiter);
-					if (!EncodeObject(prop_value, &dict_iter, &dictSubSiter)) {
+					dbus_signature_iter_next(&dictSubConcreteSiter);
+					if (!EncodeObject(prop_value, &dict_iter, &dictSubSiter, &dictSubConcreteSiter)) {
 						dbus_message_iter_close_container(&subIter, &dict_iter); 
 						printf("Failed to encode element of dictionary\n");
 						failed = true;
@@ -392,7 +403,7 @@ typedef bool (*CheckTypeCallback) (Local<Value>& value, const char* sig);
 			Local<Array> arrayData = Local<Array>::Cast(value);
 			for (unsigned int i = 0; i < arrayData->Length(); ++i) {
 				Local<Value> arrayItem = arrayData->Get(i);
-				if (!EncodeObject(arrayItem, &subIter, &arraySiter))
+				if (!EncodeObject(arrayItem, &subIter, &arraySiter, &arrayConcreteSiter))
 					break;
 			}
 
@@ -405,22 +416,33 @@ typedef bool (*CheckTypeCallback) (Local<Value>& value, const char* sig);
 		{
 			DBusMessageIter subIter;
 			DBusSignatureIter subSiter;
-
-			string str_sig = GetSignatureFromV8Type(value);
-			const char *var_sig = str_sig.c_str();
+			
+			char *var_sig;
+			if (dbus_signature_iter_get_current_type(concreteSiter) == DBUS_TYPE_VARIANT)
+			{
+				string str_sig = GetSignatureFromV8Type(value);
+				var_sig = strdup(str_sig.c_str());
+			}
+			else
+			{
+				var_sig = dbus_signature_iter_get_signature(concreteSiter);
+			}
 
 			if (!dbus_message_iter_open_container(iter, DBUS_TYPE_VARIANT, var_sig, &subIter)) {
+				dbus_free(var_sig);
 				printf("Can't open container for VARIANT type\n");
 				return false;
 			}
 
 			dbus_signature_iter_init(&subSiter, var_sig);
-			if (!EncodeObject(value, &subIter, &subSiter)) { 
+			if (!EncodeObject(value, &subIter, &subSiter, &subSiter)) { 
 				dbus_message_iter_close_container(iter, &subIter);
+				dbus_free(var_sig);
 				return false;
 			}
 
 			dbus_message_iter_close_container(iter, &subIter);
+			dbus_free(var_sig);
 
 			break;
 		}
@@ -428,7 +450,7 @@ typedef bool (*CheckTypeCallback) (Local<Value>& value, const char* sig);
 		{
 			// printf("struct\n");
 			DBusMessageIter subIter;
-			DBusSignatureIter structSiter;
+			DBusSignatureIter structSiter, structConcreteSiter;
 			
 			// Open array container to process elements in there
 			if (!dbus_message_iter_open_container(iter, DBUS_TYPE_STRUCT, NULL, &subIter)) {
@@ -440,6 +462,7 @@ typedef bool (*CheckTypeCallback) (Local<Value>& value, const char* sig);
 
 			// Getting sub-signature object
 			dbus_signature_iter_recurse(siter, &structSiter);
+			dbus_signature_iter_recurse(concreteSiter, &structConcreteSiter);
 
 			// process each elements
 			Local<Array> prop_names = value_object->GetPropertyNames();
@@ -449,12 +472,15 @@ typedef bool (*CheckTypeCallback) (Local<Value>& value, const char* sig);
 
 				Local<Value> prop_key = prop_names->Get(i);
 
-				if (!EncodeObject(value_object->Get(prop_key), &subIter, &structSiter)) {
+				if (!EncodeObject(value_object->Get(prop_key), &subIter, &structSiter, &structConcreteSiter)) {
 					printf("Failed to encode element of dictionary\n");
 					return false;
 				}
 
 				if (!dbus_signature_iter_next(&structSiter))
+					break;
+				
+				if (!dbus_signature_iter_next(&structConcreteSiter))
 					break;
 			}
 

--- a/src/encoder.h
+++ b/src/encoder.h
@@ -8,7 +8,7 @@ namespace Encoder {
 	using namespace std;
 
 	string GetSignatureFromV8Type(Local<Value>& value);
-	bool EncodeObject(Local<Value> value, DBusMessageIter *iter, const char *signature);
+	bool EncodeObject(Local<Value> value, DBusMessageIter *iter, DBusSignatureIter *siter);
 }
 
 #endif

--- a/src/encoder.h
+++ b/src/encoder.h
@@ -8,7 +8,20 @@ namespace Encoder {
 	using namespace std;
 
 	string GetSignatureFromV8Type(Local<Value>& value);
-	bool EncodeObject(Local<Value> value, DBusMessageIter *iter, DBusSignatureIter *siter);
+	
+	// expects two signatures - one for the type signature as DBus will see it,
+	// and a second that is the same as the first, except that variants requiring
+	// a particular concrete type inside should be replaced by their required concrete type.
+	// 
+	// for example, when writing a property, the property value in the Get method is
+	// a variant at the DBus interface level, but should only actually be encoded with
+	// the actual concrete type declared for the property.
+	//
+	// If the concrete type is NULL or the same as the main one, types of variant
+	// elements will be inferred based on the V8 type (and, in the case of numbers,
+	// their values)
+	bool EncodeObject(Local<Value> value, DBusMessageIter *iter,
+		const DBusSignatureIter *siter, const DBusSignatureIter *concreteSiter = NULL);
 }
 
 #endif

--- a/src/object_handler.cc
+++ b/src/object_handler.cc
@@ -77,13 +77,15 @@ namespace ObjectHandler {
 	{
 		Nan::HandleScope scope;
 		DBusMessageIter iter;
+		DBusSignatureIter siter;
 		DBusMessage *reply;
 		dbus_uint32_t serial = 0;
 
 		reply = dbus_message_new_method_return(message);
 
 		dbus_message_iter_init_append(reply, &iter);
-		if (!Encoder::EncodeObject(reply_value, &iter, signature)) {
+		dbus_signature_iter_init(&siter, signature);
+		if (!Encoder::EncodeObject(reply_value, &iter, &siter)) {
 			printf("Failed to encode reply value\n");
 		}
 

--- a/test/client-call-intdict.test.js
+++ b/test/client-call-intdict.test.js
@@ -1,0 +1,22 @@
+var withService = require('./with-service');
+var tap = require('tap');
+var DBus = require('../');
+
+tap.plan(2);
+withService('service.js', function(err, done) {
+	if (err) throw err;
+
+	var dbus = new DBus();
+	var bus = dbus.getBus('session');
+
+	bus.getInterface('test.dbus.TestService', '/test/dbus/TestService', 'test.dbus.TestService.Interface1', function(err, iface) {
+		// With options
+		iface.IntDict({ 1: 'One', 42: 'Answer' }, { timeout: 1000 }, function(err, result) {
+			tap.notSame(result, null);
+			tap.same(result, [1, 42]);
+
+			done();
+			bus.disconnect();
+		});
+	});
+});

--- a/test/service.js
+++ b/test/service.js
@@ -20,6 +20,10 @@ iface1.addMethod('Object', { in: [DBus.Define(Object)], out: DBus.Define(Object)
 	callback(null, obj);
 });
 
+iface1.addMethod('IntDict', { in: [{ type: 'a{ys}' }], out: { type: 'ay' }}, function (dict, callback) {
+	callback(null, Object.keys(dict).sort());
+})
+
 iface1.addMethod('LongProcess', { out: DBus.Define(Number) }, function(callback) {
 	setTimeout(function() {
 		callback(null, 0);


### PR DESCRIPTION
When setting properties, the implementation in terms of the 'Set' method currently does not respect the declared type of the property, because the 'Set' method argument is encoded as a variant.  This adds an extra parameter to the EncodeObject which allows a caller to indicate the concrete type to use to encode variants, and uses this capability to correctly encode property writes.

This builds on the changes in #174, but not in an essential way - I just wanted to make merging easier because I knew they would conflict otherwise.

Unfortunately, I am not aware of a good way to automate testing of the wire encoding from within Javascript, or familiar enough with the Javascript build and test tools to integrate C or C++ code into the test suite, but I have tested this against live DBus services.