### PR TITLE
Fix linking error on macOS

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -37,12 +37,11 @@
           'include_dirs': [
             '<!@(pkg-config --cflags-only-I dbus-1 | sed s/-I//g)'
           ],
-          'ldflags': [
-            '<!@(pkg-config  --libs-only-L --libs-only-other dbus-1)'
-          ],
-          'libraries': [
-            '<!@(pkg-config  --libs-only-l --libs-only-other dbus-1)'
-          ]
+          'link_settings': {
+            'libraries': [
+                '<!@(pkg-config  --libs-only-L --libs-only-l --libs-only-other dbus-1)'
+            ]
+          }
         }]
       ]
     }


### PR DESCRIPTION
Before this patch, `ld` would error that it could not find the `dylib` file on macOS. This fixes the issue