### PR TITLE
Better error handling for taken objects and names

### DIFF
--- a/lib/dbus.js
+++ b/lib/dbus.js
@@ -85,12 +85,10 @@ DBus.registerService = function(busName, serviceName) {
 	serviceMap[serviceHash] = service;
 
 	if (serviceName) {
-		process.nextTick(function() {
-			DBus._requestName(bus, _serviceName);
-		});
+		DBus._requestName(bus, _serviceName);
 	}
 
-	return service;
+	return service
 };
 
 /* Deprecated */

--- a/test/service-duplicate-error.test.js
+++ b/test/service-duplicate-error.test.js
@@ -1,0 +1,21 @@
+var tap = require('tap');
+var DBus = require('../');
+
+tap.plan(1);
+
+var service = DBus.registerService('session', 'test.dbus.TestService');
+var object = service.createObject('/test/dbus/TestService');
+var iface = object.createInterface('test.dbus.TestService.Interface1');
+iface.addSignal('Test', { types: [DBus.Define(String)] });
+iface.update()
+
+setTimeout(function() {
+	tap.throws(function() {
+    var objectd = service.createObject('/test/dbus/TestService');
+    var ifaced = objectd.createInterface('test.dbus.TestService.Interface1');
+    ifaced.addSignal('Test', { types: [DBus.Define(String)] });
+    ifaced.update();
+	})
+
+	service.disconnect()
+}, 100);


### PR DESCRIPTION
Currently there was a couple of spots where error handling with regards to existing services and objects was being ignored, which caused stray printf's and unresponsive services. I also think that deferring `DBus._requestName` to the next tick may be nice, but it makes it impossible to catch the error being thrown and handle it in a graceful way. This may be a semver major bump, since registerService now will be blocking