### PR TITLE
Add support for UNIX_FD

### DIFF
--- a/src/decoder.cc
+++ b/src/decoder.cc
@@ -42,6 +42,7 @@ namespace Decoder {
 		DBUS_BASIC_TYPE(DBUS_TYPE_INT64, dbus_int64_t, 0, Number)
 		DBUS_BASIC_TYPE(DBUS_TYPE_UINT64, dbus_uint64_t, 0, Number)
 		DBUS_BASIC_TYPE(DBUS_TYPE_DOUBLE, double, 0, Number)
+		DBUS_BASIC_TYPE(DBUS_TYPE_UNIX_FD, dbus_uint32_t, 0, Number)
 #undef DBUS_BASIC_TYPE
 
 		case DBUS_TYPE_OBJECT_PATH:

--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -268,6 +268,7 @@ typedef bool (*CheckTypeCallback) (Local<Value>& value, const char* sig);
 			break;
 		}
 
+		case DBUS_TYPE_UNIX_FD:
 		case DBUS_TYPE_INT32:
 		{
 			dbus_int32_t data = value->Int32Value();


### PR DESCRIPTION
This adds support of `DBUS_TYPE_UNIX_FD` as suggested in #134 
FDs are handled just like normal integers.