### PR TITLE
Remove object from cache when unregistered

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -44,6 +44,8 @@ Service.prototype.removeObject = function(object) {
 	var self = this;
 
 	self.bus._dbus.unregisterObjectPath(self.bus.connection, object.path);
+
+	delete self.objects[object.path];
 };
 
 Service.prototype.disconnect = function() {


### PR DESCRIPTION
After removing the object from the service on the bus, the Service was
still holding a reference in its internal cache, causing introspection
to list the object when it didn't exist anymore.