### PR TITLE
Add return self to service_interface

### DIFF
--- a/lib/service_interface.js
+++ b/lib/service_interface.js
@@ -40,6 +40,8 @@ ServiceInterface.prototype.addMethod = function(method, opts, handler) {
 	}
 
 	self.methods[method] = methodObj;
+
+	return self;
 };
 
 ServiceInterface.prototype.addProperty = function(propName, opts) {
@@ -58,6 +60,8 @@ ServiceInterface.prototype.addProperty = function(propName, opts) {
 	}
 
 	self.properties[propName] = propObj;
+
+	return self;
 };
 
 ServiceInterface.prototype.addSignal = function(signalName, opts) {
@@ -72,6 +76,8 @@ ServiceInterface.prototype.addSignal = function(signalName, opts) {
 		var args = [ signalName ].concat(Array.prototype.slice.call(arguments));
 		self.emitSignal.apply(this, args);
 	});
+
+	return self;
 };
 
 ServiceInterface.prototype.call = function(method, message, args) {
@@ -200,6 +206,8 @@ ServiceInterface.prototype.emitSignal = function() {
 	}
 
 	self.object.service.bus._dbus.emitSignal(conn, objPath, interfaceName, signalName, args, signatures);
+
+	return self;
 };
 
 ServiceInterface.prototype.update = function() {
@@ -264,4 +272,6 @@ ServiceInterface.prototype.update = function() {
 	introspection.push('</interface>');
 
 	self.introspection = introspection.join('\n');
+
+	return self;
 };


### PR DESCRIPTION
This patch add a 'return self;' to each functions in service_interface
module to use method chaining technique. This helps developers write
code more conveniently. Please refer to the example below.

    var obj = service.createObject('/test');
    obj.createInterface('test.iface')
       .addMethod('method1', ...)
       .addMethod('method2', ...)
       .update();

Signed-off-by: Inho Oh <webispy@gmail.com>