### PR TITLE
Support worker threads

### DIFF
--- a/src/dbus.cc
+++ b/src/dbus.cc
@@ -431,5 +431,5 @@ static void init(Local<Object> exports) {
   Nan::SetMethod(exports, "emitSignal", Signal::EmitSignal);
 }
 
-NODE_MODULE(dbus, init);
+NAN_MODULE_WORKER_ENABLED(dbus, init);
 }  // namespace node_dbus


### PR DESCRIPTION
Add NAN_MODULE_WORKER_ENABLED macro as a replacement for NAN_MODULE.
Closes Shouqun/node-dbus#212