### PR TITLE
Bus.prototype.reconnect to handle null connection

### DIFF
--- a/lib/bus.js
+++ b/lib/bus.js
@@ -75,9 +75,11 @@ Bus.prototype.disconnect = function(callback) {
 Bus.prototype.reconnect = function(callback) {
 	var self = this;
 
-	delete self.DBus.signalHandlers[self.connection.uniqueName];
+	if(self.connection) {
+		delete self.DBus.signalHandlers[self.connection.uniqueName];
 
-	self._dbus.releaseBus(self.connection);
+		self._dbus.releaseBus(self.connection);
+	}
 
 	switch(self.name) {
 	case 'system':
@@ -88,7 +90,7 @@ Bus.prototype.reconnect = function(callback) {
 		self.connection = self._dbus.getBus(1);
 		break;
 	}
-	
+
 	self.DBus.signalHandlers[self.connection.uniqueName] = self;
 
 	// Reregister signal handler
@@ -246,4 +248,3 @@ Bus.prototype.callMethod = function() {
 	args.push(createError);
 	this._dbus.callMethod.apply(this, args);
 };
-


### PR DESCRIPTION
The current `Bus.prototype.reconnect` throws if we call it after `Bus.prototype.disconnect` because it nulls out the `self.connection` object.