### PR TITLE
Jr add support for object path

### DIFF
--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -101,8 +101,8 @@ string GetSignatureFromV8Type(Local<Value>& value) {
     char jrFirstInitial = jrData[0];
     char jrObjTest = '/';
     if( jrFirstInitial == jrObjTest ) {
-      printf("Object path -> %s \n", jrData);
-      return const_cast<char*>(DBUS_TYPE_OBJECT_PATH_AS_STRING);
+      printf("Skipping Object path -> %s \n", jrData);
+      //return const_cast<char*>(DBUS_TYPE_OBJECT_PATH_AS_STRING);
     }
     // JR mods above this line  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     return const_cast<char*>(DBUS_TYPE_STRING_AS_STRING);

--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -94,16 +94,16 @@ string GetSignatureFromV8Type(Local<Value>& value) {
   }
   if (IsString(value)) {
     // JR mods bellow this line .........................................
-    char* jrData = strdup(*String::Utf8Value(
-      v8::Isolate::GetCurrent(),
-      value->ToString(Nan::GetCurrentContext()).ToLocalChecked())
-    );
-    char jrFirstInitial = jrData[0];
-    char jrObjTest = '/';
-    if( jrFirstInitial == jrObjTest ) {
-      printf("Skipping Object path -> %s \n", jrData);
-      //return const_cast<char*>(DBUS_TYPE_OBJECT_PATH_AS_STRING);
-    }
+    // char* jrData = strdup(*String::Utf8Value(
+    //   v8::Isolate::GetCurrent(),
+    //   value->ToString(Nan::GetCurrentContext()).ToLocalChecked())
+    // );
+    // char jrFirstInitial = jrData[0];
+    // char jrObjTest = '/';
+    // if( jrFirstInitial == jrObjTest ) {
+    //   printf("Object path -> %s \n", jrData);
+    //   return const_cast<char*>(DBUS_TYPE_OBJECT_PATH_AS_STRING);
+    // }
     // JR mods above this line  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     return const_cast<char*>(DBUS_TYPE_STRING_AS_STRING);
   }

--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -101,7 +101,7 @@ string GetSignatureFromV8Type(Local<Value>& value) {
     char jrFirstInitial = jrData[0];
     char jrObjTest = '/';
     if( jrFirstInitial == jrObjTest ) {
-      printf("Object path -> %s \n", jrData);
+      // printf("Object path -> %s \n", jrData);
       return const_cast<char*>(DBUS_TYPE_OBJECT_PATH_AS_STRING);
     }
     // JR mods above this line  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -94,16 +94,16 @@ string GetSignatureFromV8Type(Local<Value>& value) {
   }
   if (IsString(value)) {
     // JR mods bellow this line .........................................
-    // char* jrData = strdup(*String::Utf8Value(
-    //   v8::Isolate::GetCurrent(),
-    //   value->ToString(Nan::GetCurrentContext()).ToLocalChecked())
-    // );
-    // char jrFirstInitial = jrData[0];
-    // char jrObjTest = '/';
-    // if( jrFirstInitial == jrObjTest ) {
-    //   printf("Object path -> %s \n", jrData);
-    //   return const_cast<char*>(DBUS_TYPE_OBJECT_PATH_AS_STRING);
-    // }
+    char* jrData = strdup(*String::Utf8Value(
+      v8::Isolate::GetCurrent(),
+      value->ToString(Nan::GetCurrentContext()).ToLocalChecked())
+    );
+    char jrFirstInitial = jrData[0];
+    char jrObjTest = '/';
+    if( jrFirstInitial == jrObjTest ) {
+      printf("Object path -> %s \n", jrData);
+      return const_cast<char*>(DBUS_TYPE_OBJECT_PATH_AS_STRING);
+    }
     // JR mods above this line  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     return const_cast<char*>(DBUS_TYPE_STRING_AS_STRING);
   }

--- a/src/encoder.cc
+++ b/src/encoder.cc
@@ -93,6 +93,18 @@ string GetSignatureFromV8Type(Local<Value>& value) {
     return const_cast<char*>(DBUS_TYPE_DOUBLE_AS_STRING);
   }
   if (IsString(value)) {
+    // JR mods bellow this line .........................................
+    char* jrData = strdup(*String::Utf8Value(
+      v8::Isolate::GetCurrent(),
+      value->ToString(Nan::GetCurrentContext()).ToLocalChecked())
+    );
+    char jrFirstInitial = jrData[0];
+    char jrObjTest = '/';
+    if( jrFirstInitial == jrObjTest ) {
+      printf("Object path -> %s \n", jrData);
+      return const_cast<char*>(DBUS_TYPE_OBJECT_PATH_AS_STRING);
+    }
+    // JR mods above this line  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     return const_cast<char*>(DBUS_TYPE_STRING_AS_STRING);
   }
   if (IsArray(value)) {


### PR DESCRIPTION
I modified encoder.cc to detect when a string variant starts with a /.  I use this to flag it as an a string variant with type of object path instead of a simple string variant.  This allowed me to use node-dbus in my https://github.com/RuckerGauge/blePeripheral project.  