### PR TITLE
Fix empty reply warning

### DIFF
--- a/lib/service_interface.js
+++ b/lib/service_interface.js
@@ -97,7 +97,7 @@ ServiceInterface.prototype.call = function(method, message, args) {
 
 	// Preparing callback
 	args = Array.prototype.slice.call(args).concat([ function(err, value) {
-		var type;
+		var type = null;
 
 		// Error handling
 		if (err) {
@@ -112,8 +112,8 @@ ServiceInterface.prototype.call = function(method, message, args) {
 			return;
 		}
 
-		if (member.out)
-			type = member.out.type || '';
+		if (member.out && member.out.type && member.out.type.length > 0 )
+			type = member.out.type;
 
 		self.object.service.bus._sendMessageReply(message, value, type);
 	} ]);

--- a/src/object_handler.cc
+++ b/src/object_handler.cc
@@ -81,10 +81,12 @@ static void _SendMessageReply(DBusConnection* connection, DBusMessage* message,
 
   reply = dbus_message_new_method_return(message);
 
-  dbus_message_iter_init_append(reply, &iter);
-  dbus_signature_iter_init(&siter, signature);
-  if (!Encoder::EncodeObject(reply_value, &iter, &siter)) {
-    printf("Failed to encode reply value\n");
+  if(signature) {
+    dbus_message_iter_init_append(reply, &iter);
+    dbus_signature_iter_init(&siter, signature);
+    if (!Encoder::EncodeObject(reply_value, &iter, &siter)) {
+      printf("Failed to encode reply value\n");
+    }
   }
 
   // Send reply message
@@ -169,7 +171,10 @@ NAN_METHOD(SendMessageReply) {
     return;
   }
 
-  char* signature = strdup(*Nan::Utf8String(info[2]));
+  char* signature = NULL;
+  if(info[2]->IsString()) {
+    signature = strdup(*Nan::Utf8String(info[2]));
+  }
   _SendMessageReply(connection, message, info[1], signature);
   dbus_free(signature);
 


### PR DESCRIPTION
Fix "Failed to encode reply value" for empty replies.
See #195 

This is implemented by only appending the response value if a signature was is provided.