### PR TITLE
Fix build warnings

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -23,6 +23,7 @@
             'LIB_EXPAT=expat'
           ],
           'cflags': [
+            '-Wno-unused-result',
             '-std=gnu++0x',
             '<!@(pkg-config --cflags dbus-1)'
           ],

--- a/deps/libexpat/libexpat.gyp
+++ b/deps/libexpat/libexpat.gyp
@@ -56,6 +56,8 @@
         'HAVE_EXPAT_CONFIG_H'
       ],
       'cflags': [
+        '-Wno-implicit-fallthrough',
+        '-Wno-unused-but-set-variable',
         '-Wno-missing-field-initializers'
       ],
       'xcode_settings': {

--- a/src/object_handler.cc
+++ b/src/object_handler.cc
@@ -53,8 +53,9 @@ static DBusHandlerResult MessageHandler(DBusConnection* connection,
   if (!dbus_message_get_no_reply(message)) dbus_message_ref(message);
 
   // Invoke
-  Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(handler), 7,
-                    info);
+  Nan::AsyncResource asyncCB("message-handler");
+  asyncCB.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(handler), 
+                          7, info);
 
   return DBUS_HANDLER_RESULT_HANDLED;
 }
@@ -115,7 +116,7 @@ NAN_METHOD(RegisterObjectPath) {
   // Register object path
   char* object_path = strdup(*Nan::Utf8String(info[1]));
   dbus_error_init(&error);
-  dbus_bool_t ret = dbus_connection_try_register_object_path(
+  dbus_connection_try_register_object_path(
       bus->connection, object_path, &vtable, nullptr, &error);
   dbus_connection_flush(bus->connection);
   dbus_free(object_path);

--- a/src/signal.cc
+++ b/src/signal.cc
@@ -25,8 +25,9 @@ void DispatchSignal(Local<Value> info[]) {
   if (!hookSignal) return;
 
   //		MakeCallback(handler, handler, 6, info);
-  Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(handler), 6,
-                    info);
+  Nan::AsyncResource asyncCB("signal-handler");
+  asyncCB.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(handler), 
+                          6, info);
 }
 
 NAN_METHOD(SetSignalHandler) {


### PR DESCRIPTION
This fixes the warnings during the build process.

- Suppress build warning for `unused-result`
- Suppress build warning in libexpat for `implicit-fallthrough` and `unused-but-set-variable`
- Replace `Nan::MakeCallback` with `Nan::AsyncResource::runInAsyncScope`