### PR TITLE
Add callback function support to callMethod in/out defs.

### DIFF
--- a/lib/service_interface.js
+++ b/lib/service_interface.js
@@ -95,10 +95,16 @@ ServiceInterface.prototype.call = function(method, message, args) {
 		return;
 	}
 
+	var type;
+	if (typeof member.out === 'function') {
+		// allow interfaces such as 'org.freedesktop.DBus.Properties' to return out definition according arguments 
+		type = member.out.apply(this, [self.name, method, args]).type;
+	} else if (member.out) {
+		type = member.out.type || '';
+	}
+
 	// Preparing callback
 	args = Array.prototype.slice.call(args).concat([ function(err, value) {
-		var type;
-
 		// Error handling
 		if (err) {
 			var errorName = 'org.freedesktop.DBus.Error.Failed';
@@ -111,9 +117,6 @@ ServiceInterface.prototype.call = function(method, message, args) {
 
 			return;
 		}
-
-		if (member.out)
-			type = member.out.type || '';
 
 		self.object.service.bus._sendMessageReply(message, value, type);
 	} ]);
@@ -226,6 +229,9 @@ ServiceInterface.prototype.update = function() {
 		// Arguments
 		for (var index in method['in']) {
 			var arg = method['in'][index];
+			if (typeof arg === 'function') {
+				arg = arg.apply(this, [self.name, method, []]);
+			}
 			if (arg.name)
 				introspection.push('<arg direction="in" type="' + arg.type + '" name="' + arg.name + '"/>');
 			else
@@ -233,10 +239,14 @@ ServiceInterface.prototype.update = function() {
 		}
 
 		if (method['out']) {
-			if (method['out'].name)
-				introspection.push('<arg direction="out" type="' + method['out'].type + '" name="' + method['out'].name + '"/>');
+			var out_def = method['out'];
+			if (typeof out_def === 'function') {
+				out_def = out_def.apply(this, [self.name, method, []]);
+			}
+			if (out_def.name)
+				introspection.push('<arg direction="out" type="' + out_def.type + '" name="' + out_def.name + '"/>');
 			else
-				introspection.push('<arg direction="out" type="' + method['out'].type + '"/>');
+				introspection.push('<arg direction="out" type="' + out_def.type + '"/>');
 		}
 
 		introspection.push('</method>');

--- a/lib/service_object.js
+++ b/lib/service_object.js
@@ -20,6 +20,23 @@ var ServiceObject = module.exports = function(service, objectPath) {
 	});
 	self.introspectableInterface.update();
 
+	function DefineByPropName(name) {
+		return function (_, __, args) {
+			var def = Utils.Define('Auto', name);
+			if (!args || args.length != 2) return def;
+			var interfaceName = args[0];
+			var propName = args[1];
+			var iface = self['interfaces'][interfaceName];
+			if (iface) {
+				var prop = iface.properties[propName];
+				if (prop && prop.type && prop.type.type) {
+					def.type = prop.type.type;
+				}
+			}
+			return def;
+		}
+	}
+
 	// Initializing property interface
 	self.propertyInterface = self.createInterface('org.freedesktop.DBus.Properties');
 	self.propertyInterface.addMethod('Get', {
@@ -27,7 +44,7 @@ var ServiceObject = module.exports = function(service, objectPath) {
 			Utils.Define(String, 'interface_name'),
 			Utils.Define(String, 'property_name')
 		],
-		out: Utils.Define('Auto', 'value')
+		out: DefineByPropName('value')
 	}, function(interfaceName, propName, callback) {
 		var iface = self['interfaces'][interfaceName];
 		if (!iface) {
@@ -112,7 +129,6 @@ ServiceObject.prototype.updateIntrospection = function() {
 		introspection.push('<node name="' + childNodes[i] + '"/>');
 	}
 	introspection.push('</node>');
-
 	self.introspection = introspection.join('\n');
 };
 


### PR DESCRIPTION
In some scenario, addProperty does not send correct data to `DBus`.  For example, in bluez api, ManufacturerData's dict key must be uint16), but JS does not support number-type key. Since`out` value was forced to set to `Utils.Define('Auto', 'value')` in when implementing `org.freedesktop.DBus.Properties`, the returned value's `prop_key` was mis-transformed to `string`.

This PR introduced function support when defining method, so value type could be dynamic returned according args.